### PR TITLE
Fixed variable detection in syntax class (stroop working again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,14 +42,12 @@
     "pixi-sound": "^1.4.0",
     "pixi.js": "^4.4.1",
     "random-seed": "^0.3.0",
-    "screenfull": "^3.0.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {
     "babel-core": "^6.24.0",
     "babel-loader": "^6.4.0",
     "babel-preset-env": "^1.2.2",
-    "canvas": "^1.6.5",
     "chai": "^3.5.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.27.3",
@@ -76,8 +74,7 @@
     "typescript": "^2.2.1",
     "url-loader": "^0.5.8",
     "webpack": "^2.2.1",
-    "webpack-dev-server": "^2.4.2",
-    "xmldom": "^0.1.27"
+    "webpack-dev-server": "^2.4.2"
   },
   "babel": {
     "presets": [

--- a/src/js/osweb/backends/canvas.js
+++ b/src/js/osweb/backends/canvas.js
@@ -74,12 +74,11 @@ export default class Canvas {
         let doc;
         try{
             doc = new DOMParser().parseFromString(str, "text/html");
+            return Array.from(doc.childNodes).some(node => node.nodeType === 1);
         }catch(e){
-            // Account for the absence of DOMParser in node.js
-            //const DOMParser = require('xmldom').DOMParser;
-            //doc = new DOMParser().parseFromString(str, "text/html");
+            console.error("Could not parse DOM: " + e.message);
         }
-        return Array.from(doc.childNodes).some(node => node.nodeType === 1);
+        
     }
 
     /** Exit the display and return to default settings. */

--- a/src/js/osweb/backends/canvas.js
+++ b/src/js/osweb/backends/canvas.js
@@ -585,10 +585,7 @@ export default class Canvas {
      */
     image(fname, center, x, y, scale) {
         // Get image from file pool.
-        console.log(fname);
         var name = this.experiment._runner._syntax.remove_quotes(fname);
-        console.log(name);
-        console.log(this.experiment._runner._pool);
         var img = this.experiment._runner._pool[name].data;
 
         // Create a temporary canvas to make an image data array.        

--- a/src/js/osweb/classes/python_workspace.js
+++ b/src/js/osweb/classes/python_workspace.js
@@ -1,3 +1,5 @@
+import { isBoolean } from 'underscore';
+
 /** Class representing a python workspace. */
 export default class PythonWorkspace {
     /**
@@ -16,13 +18,13 @@ export default class PythonWorkspace {
      */
     _eval(bytecode) {
         // Check wich type of expression must be evaled.
-        if (typeof bytecode === 'boolean') {
+        if (isBoolean(bytecode)) {
             return bytecode;
         } else if (typeof bytecode === 'string') {
-            // Open sesame script, first check for parameter values. 
+            // Open sesame script, first check for parameter values.   
             bytecode = this._runner._syntax.eval_text(bytecode);
 
-            // Evaluate the expression.
+            //Evaluate the expression.
             var eval_string = this._runner._syntax.remove_quotes(bytecode);
             if (eval_string == "always") {
                 return true;

--- a/src/js/osweb/classes/syntax.js
+++ b/src/js/osweb/classes/syntax.js
@@ -30,8 +30,9 @@ export default class Syntax {
             if (cnd[0] == '=') {
                 cnd = cnd.substr(1);
             } else {
+                cnd = this.remove_quotes(cnd);
                 // Scan for literals (strings, numbers, etc).
-                cnd = cnd.replace(/(?!(?:and|or|not)\b)(?:".*?"|'.*?'|\[\w*?\]|\b\w+\b)/g , (match, offset, string) => {
+                cnd = cnd.replace(/(?!(?:and|or|not)\b)(?:".*?"|'.*?'|\[\w+?\]|\b\w+\b)/g , (match, offset, string) => {
                     // Check if match is not a variable, already inside quotes or a number.
                     if(string[offset] == '[' && string[offset+match.length-1] == ']' ||     
                         [`"`,`'`].includes(string[offset]) && string[offset] == string[offset+match.length-1]
@@ -45,7 +46,7 @@ export default class Syntax {
                 });
 
                 // Replace all valid variables inside []
-                cnd = cnd.replace(/\[([a-z0-9]+|=.+)\]/g, (match, content, offset, string) => {
+                cnd = cnd.replace(/\[(\w+?|=.+)\]/g, (match, content, offset, string) => {
                     // Check if the current match is escaped, and simply return it untouched if so.
                     if(string[offset-1] == "\\" && string[offset-2] != "\\") return match;
                     return `var.${content}`;

--- a/src/js/osweb/classes/syntax.js
+++ b/src/js/osweb/classes/syntax.js
@@ -98,7 +98,7 @@ export default class Syntax {
      * @param {Object} variable - The variables used for evaluation.
      * @return {Boolean|Number|Object|String} - The result of the evaluated text.
      */
-    eval_text(text, vars, roundFloat, variable) {
+    eval_text(text, vars, roundFloat) {
         // if pTxt is an object then it is a parsed python expression.
         if (isObject(text)) {
             return this._runner._pythonParser._run_statement(text);
@@ -110,7 +110,7 @@ export default class Syntax {
 
         /** The replacer function detects variable entries in the passed text
         and replaces them with variable values as found in OpenSesame's var store */
-        let result = text.replace(/\[([a-z0-9]+|=.+)\]/g, (match, content, offset, string) => {
+        let result = text.replace(/\[(\w+|=.+)\]/g, (match, content, offset, string) => {
             // Check if the current match is escaped, and simply return it untouched if so.
             if(string[offset-1] == "\\" && string[offset-2] != "\\") return match;
 

--- a/test/index.html
+++ b/test/index.html
@@ -3,23 +3,26 @@
 <head>
   <meta charset="utf-8">
   <title>Osweb unit tests</title>
-  <link rel="stylesheet" href="../public_html/css/osweb.css"/>
+  <link href="../public_html/css/styles.css" rel="stylesheet">
   <link rel="stylesheet" media="all" href="../node_modules/mocha/mocha.css">
+
 </head>
 <body>
   <div class="container">
     <div class="row">
       <div class="col-md-12">
         <h1>
-          <img style="height: 40px" src='../public_html/img/opensesame.png'><span style="vertical-align: middle">&nbsp;Osweb - Unit tests</span>
+         <span style="vertical-align: middle">&nbsp;Osweb - Unit tests</span>
         </h1>
         <div id="mocha"><p><a href=".">Index</a></p></div>
         <div id="messages"></div>
         <div id="fixtures"></div>
+        <div id='renderTarget' style="visibility:hidden"></div>
         <script src="../node_modules/mocha/mocha.js"></script>
         <script src="../node_modules/chai/chai.js"></script>
+        <script src="../node_modules/sinon/pkg/sinon-2.1.0.js"></script>
+        <script src="../public_html/js/gzip.js"></script>
         <script src="../public_html/js/osweb.js"></script>
-        <script src="../public_html/js/interface.js"></script>
         <script>mocha.setup('bdd')</script>
         <script src="test.js"></script>
         <script>mocha.run();</script>

--- a/test/test.js
+++ b/test/test.js
@@ -64,64 +64,64 @@ if (node_mode) {
 	var expect = chai.expect;
 }
 
-var Script = '---' + '\n' +
-	'API: 2' + '\n' +
-	'OpenSesame: 3.0.2' + '\n' +
-	'Platform: nt' + '\n' +
-	'---' + '\n' +
-	'set width 1024' + '\n' +
-	'set uniform_coordinates "yes"' + '\n' +
-	'set title "New experiment"' + '\n' +
-	'set subject_parity "even"' + '\n' +
-	'set subject_nr 0' + '\n' +
-	'set start "block"' + '\n' +
-	'set height 768' + '\n' +
-	'set foreground "white"' + '\n' +
-	'set description "Default description"' + '\n' +
-	'set coordinates "uniform"' + '\n' +
-	'set compensation 0' + '\n' +
-	'set canvas_backend "xpyriment"' + '\n' +
-	'set background "black"' + '\n' +
-	'' + '\n' +
-	'define sequence block' + '\n' +
-	'	set flush_keyboard "yes"' + '\n' +
-	'	set description "Runs a number of items in sequence"' + '\n' +
-	'	run new_loop always' + '\n' +
-	'' + '\n' +
-	'define loop new_loop' + '\n' +
-	'	set skip 0' + '\n' +
-	'	set repeat 1' + '\n' +
-	'	set order "sequential"' + '\n' +
-	'	set offset "no"' + '\n' +
-	'	set item "trial"' + '\n' +
-	'	set description "Repeatedly runs another item"' + '\n' +
-	'	set cycles 2' + '\n' +
-	'	set column_order "stimulus;counter"' + '\n' +
-	'	set break_if "never"' + '\n' +
-	'	setcycle 0 stimulus "page 1<br/><br/>Next line"' + '\n' +
-	'	setcycle 0 counter "1"' + '\n' +
-	'	setcycle 1 stimulus "page 2"' + '\n' +
-	'	setcycle 1 counter "2"' + '\n' +
-	'	setcycle 2 stimulus "page 3"' + '\n' +
-	'	setcycle 2 counter "3"' + '\n' +
-	'	run trial' + '\n' +
-	'' + '\n' +
-	'define sequence trial' + '\n' +
-	'	set flush_keyboard "yes"' + '\n' +
-	'	set description "Runs a number of items in sequence"' + '\n' +
-	'	run welcome always' + '\n' +
-	'' + '\n' +
-	'define sketchpad welcome' + '\n' +
-	'	set start_response_interval "no"' + '\n' +
-	'	set reset_variables "no"' + '\n' +
-	'	set duration "keypress"' + '\n' +
-	'	set description "Displays stimuli"' + '\n' +
-	'	draw textline center=1 color=white font_bold=no font_family=serif font_italic=no font_size=32 html=yes show_if=always text="OpenSesame 3.0.0 [stimulus]" x=0 y=0 z_index=0' + '\n';
+// var Script = '---' + '\n' +
+// 	'API: 2' + '\n' +
+// 	'OpenSesame: 3.0.2' + '\n' +
+// 	'Platform: nt' + '\n' +
+// 	'---' + '\n' +
+// 	'set width 1024' + '\n' +
+// 	'set uniform_coordinates "yes"' + '\n' +
+// 	'set title "New experiment"' + '\n' +
+// 	'set subject_parity "even"' + '\n' +
+// 	'set subject_nr 0' + '\n' +
+// 	'set start "block"' + '\n' +
+// 	'set height 768' + '\n' +
+// 	'set foreground "white"' + '\n' +
+// 	'set description "Default description"' + '\n' +
+// 	'set coordinates "uniform"' + '\n' +
+// 	'set compensation 0' + '\n' +
+// 	'set canvas_backend "xpyriment"' + '\n' +
+// 	'set background "black"' + '\n' +
+// 	'' + '\n' +
+// 	'define sequence block' + '\n' +
+// 	'	set flush_keyboard "yes"' + '\n' +
+// 	'	set description "Runs a number of items in sequence"' + '\n' +
+// 	'	run new_loop always' + '\n' +
+// 	'' + '\n' +
+// 	'define loop new_loop' + '\n' +
+// 	'	set skip 0' + '\n' +
+// 	'	set repeat 1' + '\n' +
+// 	'	set order "sequential"' + '\n' +
+// 	'	set offset "no"' + '\n' +
+// 	'	set item "trial"' + '\n' +
+// 	'	set description "Repeatedly runs another item"' + '\n' +
+// 	'	set cycles 2' + '\n' +
+// 	'	set column_order "stimulus;counter"' + '\n' +
+// 	'	set break_if "never"' + '\n' +
+// 	'	setcycle 0 stimulus "page 1<br/><br/>Next line"' + '\n' +
+// 	'	setcycle 0 counter "1"' + '\n' +
+// 	'	setcycle 1 stimulus "page 2"' + '\n' +
+// 	'	setcycle 1 counter "2"' + '\n' +
+// 	'	setcycle 2 stimulus "page 3"' + '\n' +
+// 	'	setcycle 2 counter "3"' + '\n' +
+// 	'	run trial' + '\n' +
+// 	'' + '\n' +
+// 	'define sequence trial' + '\n' +
+// 	'	set flush_keyboard "yes"' + '\n' +
+// 	'	set description "Runs a number of items in sequence"' + '\n' +
+// 	'	run welcome always' + '\n' +
+// 	'' + '\n' +
+// 	'define sketchpad welcome' + '\n' +
+// 	'	set start_response_interval "no"' + '\n' +
+// 	'	set reset_variables "no"' + '\n' +
+// 	'	set duration "keypress"' + '\n' +
+// 	'	set description "Displays stimuli"' + '\n' +
+// 	'	draw textline center=1 color=white font_bold=no font_family=serif font_italic=no font_size=32 html=yes show_if=always text="OpenSesame 3.0.0 [stimulus]" x=0 y=0 z_index=0' + '\n';
 
-// Definition of the experiment object and its properties.
-var Experiment = {
-	'source': Script
-};
+// // Definition of the experiment object and its properties.
+// var Experiment = {
+// 	'source': Script
+// };
 
 var runner = osweb.getRunner(divTarget);
 
@@ -205,6 +205,7 @@ describe('Syntax', function() {
 		var tmp_var_store = new VarStore({syntax: runner._syntax}, null);
 		tmp_var_store.width = 1024;
 		tmp_var_store.height = 768;
+		tmp_var_store.my_var99 = 99;
 
 		it("Should only parse real variables: \\\\[width] = \\[width] = [width]", function() {
 			expect(runner._syntax.eval_text(
@@ -219,6 +220,11 @@ describe('Syntax', function() {
 		it("Should not try to parse a variable if [] contents contain non-alphanumeric (unicode) characters: [nóvar]", function() {
 			expect(runner._syntax.eval_text(
 				'[nóvar]', tmp_var_store)).to.equal('[nóvar]');
+		});
+
+		it("Should parse variables with underscores and numbers: [my_var99]", function() {
+			expect(runner._syntax.eval_text(
+				'[my_var99]', tmp_var_store)).to.equal('99');
 		});
 
 		it("Should not try to parse a variable if it is preceded by a backslash: \\[width]", function() {
@@ -310,29 +316,32 @@ describe('Syntax', function() {
 	});
 });
 
-describe('Canvas', function() {
-		// Suppress error output
-	var stub;
-	beforeEach(function(){
-		stub = sinon.stub(console, "error");
-	});
-	afterEach(function(){
-		stub.restore();
-	});
+if(!node_mode){
+	describe('Canvas', function() {
+			// Suppress error output
+		var stub;
+		beforeEach(function(){
+			stub = sinon.stub(console, "error");
+		});
+		afterEach(function(){
+			stub.restore();
+		});
 
-	var canvas = new Canvas({
-		_runner: runner
-	});
+		var canvas = new Canvas({
+			_runner: runner
+		});
 
-	it("should recognize valid HTML in a string", function() {
-		expect(canvas._containsHTML("<p>Hey</p>")).to.be.true;
-	});
-	it("should recognize a string without html markup", function() {
-		expect(canvas._containsHTML("Hey")).to.be.false;
-	});
-	it("should not mistake everything between < and > for html", function() {
-		expect(canvas._containsHTML("a < b && b > c")).to.be.false;
-	});
+		it("should recognize valid HTML in a string", function() {
+			expect(canvas._containsHTML("<p>Hey</p>")).to.be.true;
+		});
+		it("should recognize a string without html markup", function() {
+			expect(canvas._containsHTML("Hey")).to.be.false;
+		});
+		it("should not mistake everything between < and > for html", function() {
+			expect(canvas._containsHTML("a < b && b > c")).to.be.false;
+		});
+	
+
 	
 
 	// for colorspec in [
@@ -365,7 +374,8 @@ describe('Canvas', function() {
 	// 	print(u'Checking incorrect %s (%s)' \
 	// 		% (str(colorspec), type(colorspec)))
 	// 	self.assertRaises(osexception, color.to_hex, colorspec)
-});
+	});
+}
 
 describe('response', function() {
 	// def assertState(self, response, response_time, correct, total_responses,

--- a/test/test.js
+++ b/test/test.js
@@ -55,13 +55,20 @@ if (node_mode) {
 	}
 
 	var osweb = require('../src/js/osweb/index.js').default;
-	var divTarget = document.createElement("div");
-	divTarget.id = "renderTarget";
+	var renderTarget = document.createElement("div");
+	renderTarget.id = "renderTarget";
 	
 	var VarStore = require('../src/js/osweb/classes/var_store.js').default;
 	var Canvas = require('../src/js/osweb/backends/canvas.js').default;
+	var runner = osweb.getRunner(renderTarget);
 } else {
 	var expect = chai.expect;
+	var stub = sinon.stub;
+	var runner = osweb.getRunner('renderTarget');
+
+	var VarStore = function(data, second){
+		this._runner = data.runner;
+	}
 }
 
 // var Script = '---' + '\n' +
@@ -123,16 +130,14 @@ if (node_mode) {
 // 	'source': Script
 // };
 
-var runner = osweb.getRunner(divTarget);
-
 describe('Syntax', function() {
 	// Suppress error output
-	var stub;
+	var console_stub;
 	beforeEach(function(){
-		stub = sinon.stub(console, "error");
+		console_stub = sinon.stub(console, "error");
 	});
 	afterEach(function(){
-		stub.restore();
+		console_stub.restore();
 	});
 
 	describe('parse_cmd()', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -285,9 +285,17 @@ describe('Syntax', function() {
 			expect(runner._syntax.compile_cond(
 				'NEVER', false)).to.equal(false);
 		});
+		it("Should quote literals at the end of the string", function(){
+			expect(runner._syntax.compile_cond(
+				'[cue_side] = left', false)).to.equal('var.cue_side == "left"');
+		});
 		it("Should convert a single = to double ==", function() {
 			expect(runner._syntax.compile_cond(
 				'[width] = 1024', false)).to.equal('var.width == 1024');
+		});
+		it("Should handle underscores in variable names", function() {
+			expect(runner._syntax.compile_cond(
+				'[my_var99] = 1024', false)).to.equal('var.my_var99 == 1024');
 		});
 		it("Should handle lack of spaces surrounding = correctly", function() {
 			expect(runner._syntax.compile_cond(


### PR DESCRIPTION
The eval_text() function didn't process variable names that contained underscores correctly, so it ignored [stimuli_image]. I fixed the regex that detects variable names (now using \w+) and everything (or specifically the stroop task) seems to work again. Could you check this?