### PR TITLE
Make variable matching non-greedy

### DIFF
--- a/src/js/osweb/classes/syntax.js
+++ b/src/js/osweb/classes/syntax.js
@@ -118,7 +118,7 @@ export default class Syntax {
 
         /** The replacer function detects variable entries in the passed text
         and replaces them with variable values as found in OpenSesame's var store */
-        let result = text.replace(/\[(\w+|=.+)\]/g, (match, content, offset, string) => {
+        let result = text.replace(/\[(\w+|=.+?)\]/g, (match, content, offset, string) => {
             // Check if the current match is escaped, and simply return it untouched if so.
             if (string[offset-1] === "\\" && string[offset-2] !== "\\") return match;
 


### PR DESCRIPTION
Strings such as:

~~~
End of block [=var.count_block_sequence+1]<br /><br />Your average response time was [avg_rt] ms<br />Your accuracy was [acc] %<br /><br />Press any key to continue
~~~

Caused a crash because the regular expression to match `[]` expressions was greedy. I believe this small fix is sufficient.

However, I haven't been able to get the unit testing working, so please double check!