### PR TITLE
Make canvas-prebuilt a default devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
 	"name": "osweb",
 	"version": "1.0.0",
 	"lockfileVersion": 1,
+	"requires": true,
 	"dependencies": {
 		"abab": {
 			"version": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
@@ -16,7 +17,11 @@
 		"accepts": {
 			"version": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
 			"integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+				"negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+			}
 		},
 		"acorn": {
 			"version": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz",
@@ -26,17 +31,27 @@
 		"acorn-dynamic-import": {
 			"version": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
 			"integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz"
+			}
 		},
 		"acorn-globals": {
 			"version": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
 			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz"
+			}
 		},
 		"ajv": {
 			"version": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
 			"integrity": "sha1-tu50ZXuZOgHc5Et5RNVvSFgo1b0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+				"json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+			}
 		},
 		"ajv-keywords": {
 			"version": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
@@ -51,7 +66,12 @@
 		"align-text": {
 			"version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+				"longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+				"repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+			}
 		},
 		"alphanum-sort": {
 			"version": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
@@ -82,7 +102,11 @@
 		"anymatch": {
 			"version": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
 			"integrity": "sha1-o+Uvo5FoyCX/V7AkgSbOWo/5VQc=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+				"micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+			}
 		},
 		"aproba": {
 			"version": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
@@ -93,6 +117,10 @@
 			"version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
 			"integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
 			"dev": true,
+			"requires": {
+				"delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+				"readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz"
+			},
 			"dependencies": {
 				"isarray": {
 					"version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -102,19 +130,34 @@
 				"readable-stream": {
 					"version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
 					"integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+						"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+						"process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+						"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+						"util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+					}
 				}
 			}
 		},
 		"argparse": {
 			"version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+			}
 		},
 		"arr-diff": {
 			"version": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"arr-flatten": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz"
+			}
 		},
 		"arr-flatten": {
 			"version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.0.1.tgz",
@@ -139,7 +182,10 @@
 		"array-union": {
 			"version": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+			}
 		},
 		"array-uniq": {
 			"version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
@@ -164,12 +210,20 @@
 		"asn1.js": {
 			"version": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
 			"integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+			}
 		},
 		"assert": {
 			"version": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
 			"integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+			}
 		},
 		"assert-plus": {
 			"version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
@@ -184,7 +238,10 @@
 		"async": {
 			"version": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
 			"integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+			}
 		},
 		"async-each": {
 			"version": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
@@ -204,7 +261,15 @@
 		"autoprefixer": {
 			"version": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
 			"integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.6.tgz",
+				"caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000639.tgz",
+				"normalize-range": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+				"num2fraction": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+			}
 		},
 		"aws-sign2": {
 			"version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
@@ -219,49 +284,122 @@
 		"babel-code-frame": {
 			"version": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
 			"integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+				"esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+				"js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+			}
 		},
 		"babel-core": {
 			"version": "6.25.0",
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
 			"integrity": "sha1-fdQrBGPHQunVKW3rPsZ6kyLa1yk=",
 			"dev": true,
+			"requires": {
+				"babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+				"babel-generator": "6.25.0",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+				"babel-register": "6.24.1",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-template": "6.25.0",
+				"babel-traverse": "6.25.0",
+				"babel-types": "6.25.0",
+				"babylon": "6.17.4",
+				"convert-source-map": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.4.0.tgz",
+				"debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+				"json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+				"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+				"minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+				"path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+				"private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
+				"slash": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+				"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+			},
 			"dependencies": {
 				"babel-generator": {
 					"version": "6.25.0",
 					"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
 					"integrity": "sha1-M6GvcNXyiQrrRlpKd5PB32qeqfw=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+						"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+						"babel-types": "6.25.0",
+						"detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+						"jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+						"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+						"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+						"trim-right": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+					}
 				},
 				"babel-helpers": {
 					"version": "6.24.1",
 					"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 					"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+						"babel-template": "6.25.0"
+					}
 				},
 				"babel-register": {
 					"version": "6.24.1",
 					"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
 					"integrity": "sha1-fhDhOi9xBlvfrVoXh7pFvKbe118=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"babel-core": "6.25.0",
+						"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+						"core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+						"home-or-tmp": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+						"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+						"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+						"source-map-support": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz"
+					}
 				},
 				"babel-template": {
 					"version": "6.25.0",
 					"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
 					"integrity": "sha1-ZlJBFmt8KqTGGdceGSlpVSsQwHE=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+						"babel-traverse": "6.25.0",
+						"babel-types": "6.25.0",
+						"babylon": "6.17.4",
+						"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+					}
 				},
 				"babel-traverse": {
 					"version": "6.25.0",
 					"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
 					"integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+						"babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+						"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+						"babel-types": "6.25.0",
+						"babylon": "6.17.4",
+						"debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+						"globals": "https://registry.npmjs.org/globals/-/globals-9.16.0.tgz",
+						"invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+						"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+					}
 				},
 				"babel-types": {
 					"version": "6.25.0",
 					"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
 					"integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+						"esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+						"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+						"to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+					}
 				},
 				"babylon": {
 					"version": "6.17.4",
@@ -274,72 +412,145 @@
 		"babel-helper-builder-binary-assignment-operator-visitor": {
 			"version": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.22.0.tgz",
 			"integrity": "sha1-Kd9WvhRNgb3qwIJiv6QdLF6Rzc0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-explode-assignable-expression": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.22.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-helper-call-delegate": {
 			"version": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.22.0.tgz",
 			"integrity": "sha1-EZkhtWEg8X6drj90tPXMe8wbN+8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-hoist-variables": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.22.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-helper-define-map": {
 			"version": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.23.0.tgz",
 			"integrity": "sha1-FET5YMlpHWmiztaiBTFfj9AIBOc=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
+				"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+			}
 		},
 		"babel-helper-explode-assignable-expression": {
 			"version": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.22.0.tgz",
 			"integrity": "sha1-yXv3bu0+C65ASBIfK52uGk59BHg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-helper-function-name": {
 			"version": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz",
 			"integrity": "sha1-JXQtZxdciQPb5LbLnZ4fy43PI6Y=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz",
+				"babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-helper-get-function-arity": {
 			"version": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz",
 			"integrity": "sha1-C+tGStadxzR0EKxq3p8DpQY09c4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-helper-hoist-variables": {
 			"version": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.22.0.tgz",
 			"integrity": "sha1-Pqy/cx2AcFhF3S6XGPYAz7m0unI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-helper-optimise-call-expression": {
 			"version": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.23.0.tgz",
 			"integrity": "sha1-8+5+7TVbQoITizPQK3g2nkcGIvU=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-helper-regex": {
 			"version": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz",
 			"integrity": "sha1-efUyvhZHsfDuNHS19cPaWAAdJH0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
+				"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+			}
 		},
 		"babel-helper-remap-async-to-generator": {
 			"version": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.22.0.tgz",
 			"integrity": "sha1-IYaucyeO0DuLFc7QiWCdqYEFM4M=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz",
+				"babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-helper-replace-supers": {
 			"version": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.23.0.tgz",
 			"integrity": "sha1-7q+K2bWOxDN8qUIjus3KH42bS/0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-optimise-call-expression": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.23.0.tgz",
+				"babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz",
+				"babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-loader": {
 			"version": "https://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
 			"integrity": "sha1-CzQRLVsHSKjc2/Uaz2+b1C1QuMo=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"find-cache-dir": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+				"loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+				"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+			}
 		},
 		"babel-messages": {
 			"version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-check-es2015-constants": {
 			"version": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-syntax-async-functions": {
 			"version": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
@@ -359,144 +570,299 @@
 		"babel-plugin-transform-async-to-generator": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.22.0.tgz",
 			"integrity": "sha1-GUtpOOwZWtNu/EwzqXGs8A2M014=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-remap-async-to-generator": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.22.0.tgz",
+				"babel-plugin-syntax-async-functions": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.23.0.tgz",
 			"integrity": "sha1-5IiVzws3W+FIzXyIebQicHoFO1E=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz",
+				"babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
+				"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-classes": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.23.0.tgz",
 			"integrity": "sha1-SbU/MmICov0bO7ql4u3YpPeGQ8E=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-define-map": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.23.0.tgz",
+				"babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz",
+				"babel-helper-optimise-call-expression": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.23.0.tgz",
+				"babel-helper-replace-supers": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.23.0.tgz",
+				"babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz",
+				"babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.22.0.tgz",
 			"integrity": "sha1-fDg+lim7pIIMEbBCW91ikPfwV+c=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.22.0.tgz",
 			"integrity": "sha1-ZyOXAxwhYQ1y3Su7C6n7Ynfhw2s=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.22.0.tgz",
 			"integrity": "sha1-9fzIsJCT+aI8dqw9njksPsS3cQQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-function-name": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.23.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-literals": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.0.tgz",
 			"integrity": "sha1-oZEfubfsfgWkOmPFmVAHVXvPai4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.0.tgz",
 			"integrity": "sha1-6SGu+3LCzCbLA9EHYmFWQTIiE08=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-plugin-transform-strict-mode": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.23.0.tgz",
 			"integrity": "sha1-rjRpIn/6w5sDENkP7HO/3E9jF7A=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-hoist-variables": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.22.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.0.tgz",
 			"integrity": "sha1-/V+mNSHK6NJzknw5WK/XwGdzNFA=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.22.0.tgz",
 			"integrity": "sha1-2qYOEUoELqdp3VP+Uo/IIxHrmPw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-replace-supers": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.23.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.23.0.tgz",
 			"integrity": "sha1-OiqrtwyK+UXVzjhvGkJQYlqDrjs=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-call-delegate": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.22.0.tgz",
+				"babel-helper-get-function-arity": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz",
+				"babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.22.0.tgz",
 			"integrity": "sha1-i6d24K/6pgv/IekhQDuKZSov9yM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-spread": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.22.0.tgz",
 			"integrity": "sha1-qzFoKehm7j9LnrlpOXV9GaW8RZM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.22.0.tgz",
 			"integrity": "sha1-jZzCfn7h3s/mVFT7mGRSoEphPSA=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-regex": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
+			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.22.0.tgz",
 			"integrity": "sha1-1XyDNSgZGOVO8FMRjObrEIRoCE0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-helper-builder-binary-assignment-operator-visitor": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.22.0.tgz",
+				"babel-plugin-syntax-exponentiation-operator": "https://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+			}
 		},
 		"babel-plugin-transform-regenerator": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz",
 			"integrity": "sha1-ZXQFk6MZxEUiFXU41pC4QJRhfqY=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"regenerator-transform": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz"
+			}
 		},
 		"babel-plugin-transform-strict-mode": {
 			"version": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz",
 			"integrity": "sha1-4AjfATQP3IfpWdplmRt+BZcMjHw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz"
+			}
 		},
 		"babel-preset-env": {
 			"version": "1.5.2",
 			"resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.5.2.tgz",
 			"integrity": "sha1-zUrpCm6Utwn5c3SzPl+LmDVWre8=",
 			"dev": true,
+			"requires": {
+				"babel-plugin-check-es2015-constants": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+				"babel-plugin-syntax-trailing-function-commas": "https://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
+				"babel-plugin-transform-async-to-generator": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.22.0.tgz",
+				"babel-plugin-transform-es2015-arrow-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+				"babel-plugin-transform-es2015-block-scoped-functions": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+				"babel-plugin-transform-es2015-block-scoping": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.23.0.tgz",
+				"babel-plugin-transform-es2015-classes": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.23.0.tgz",
+				"babel-plugin-transform-es2015-computed-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.22.0.tgz",
+				"babel-plugin-transform-es2015-destructuring": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+				"babel-plugin-transform-es2015-duplicate-keys": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.22.0.tgz",
+				"babel-plugin-transform-es2015-for-of": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+				"babel-plugin-transform-es2015-function-name": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.22.0.tgz",
+				"babel-plugin-transform-es2015-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+				"babel-plugin-transform-es2015-modules-amd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.0.tgz",
+				"babel-plugin-transform-es2015-modules-commonjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.0.tgz",
+				"babel-plugin-transform-es2015-modules-systemjs": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.23.0.tgz",
+				"babel-plugin-transform-es2015-modules-umd": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.0.tgz",
+				"babel-plugin-transform-es2015-object-super": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.22.0.tgz",
+				"babel-plugin-transform-es2015-parameters": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.23.0.tgz",
+				"babel-plugin-transform-es2015-shorthand-properties": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.22.0.tgz",
+				"babel-plugin-transform-es2015-spread": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+				"babel-plugin-transform-es2015-sticky-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.22.0.tgz",
+				"babel-plugin-transform-es2015-template-literals": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+				"babel-plugin-transform-es2015-typeof-symbol": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+				"babel-plugin-transform-es2015-unicode-regex": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.22.0.tgz",
+				"babel-plugin-transform-exponentiation-operator": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.22.0.tgz",
+				"babel-plugin-transform-regenerator": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz",
+				"browserslist": "2.1.5",
+				"invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+				"semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+			},
 			"dependencies": {
 				"browserslist": {
 					"version": "2.1.5",
 					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-2.1.5.tgz",
 					"integrity": "sha1-6IJVDfPRzW1IHBo+ADjyuvE6RxE=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"caniuse-lite": "1.0.30000696",
+						"electron-to-chromium": "1.3.15"
+					}
 				},
 				"electron-to-chromium": {
 					"version": "1.3.15",
@@ -509,22 +875,50 @@
 		"babel-runtime": {
 			"version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
 			"integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"core-js": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+				"regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.3.tgz"
+			}
 		},
 		"babel-template": {
 			"version": "https://registry.npmjs.org/babel-template/-/babel-template-6.23.0.tgz",
 			"integrity": "sha1-BNTycK27OqcEqBQ64m+qUpI45jg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
+				"babylon": "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz",
+				"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+			}
 		},
 		"babel-traverse": {
 			"version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.23.1.tgz",
 			"integrity": "sha1-08tZAQ7NBql9gTEAZflmtpnhT0g=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+				"babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
+				"babylon": "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz",
+				"debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+				"globals": "https://registry.npmjs.org/globals/-/globals-9.16.0.tgz",
+				"invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+				"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+			}
 		},
 		"babel-types": {
 			"version": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
 			"integrity": "sha1-uxcXnXU4utOM0MnhFdNA935+ms8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+				"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+				"to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.2.tgz"
+			}
 		},
 		"babylon": {
 			"version": "https://registry.npmjs.org/babylon/-/babylon-6.16.1.tgz",
@@ -550,7 +944,10 @@
 			"version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"requires": {
+				"tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+			}
 		},
 		"big.js": {
 			"version": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
@@ -569,7 +966,10 @@
 		"block-stream": {
 			"version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+			}
 		},
 		"bluebird": {
 			"version": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
@@ -586,6 +986,14 @@
 			"resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
 			"integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
 			"dev": true,
+			"requires": {
+				"array-flatten": "2.1.1",
+				"deep-equal": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+				"dns-equal": "1.0.0",
+				"dns-txt": "2.0.2",
+				"multicast-dns": "6.1.1",
+				"multicast-dns-service-types": "1.1.0"
+			},
 			"dependencies": {
 				"array-flatten": {
 					"version": "2.1.1",
@@ -603,7 +1011,10 @@
 		"boom": {
 			"version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 			"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+			}
 		},
 		"bootstrap": {
 			"version": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.3.7.tgz",
@@ -612,12 +1023,21 @@
 		"brace-expansion": {
 			"version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
 			"integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+				"concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+			}
 		},
 		"braces": {
 			"version": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"expand-range": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+				"preserve": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+				"repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+			}
 		},
 		"brorand": {
 			"version": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
@@ -632,42 +1052,84 @@
 		"browserify-aes": {
 			"version": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
 			"integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"buffer-xor": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+				"cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
+				"create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+				"evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+			}
 		},
 		"browserify-cipher": {
 			"version": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
 			"integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"browserify-aes": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+				"browserify-des": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+				"evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz"
+			}
 		},
 		"browserify-des": {
 			"version": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
 			"integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
+				"des.js": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+			}
 		},
 		"browserify-rsa": {
 			"version": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
 			"integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+				"randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
+			}
 		},
 		"browserify-sign": {
 			"version": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
 			"integrity": "sha1-EHc5EMPCBtVCCkaq2GlPgguFlo8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+				"browserify-rsa": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+				"create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+				"create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
+				"elliptic": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"parse-asn1": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz"
+			}
 		},
 		"browserify-zlib": {
 			"version": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
 			"integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"pako": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+			}
 		},
 		"browserslist": {
 			"version": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.6.tgz",
 			"integrity": "sha1-r5hYnObnqwlhjSlFH6rLgSIL07o=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000639.tgz",
+				"electron-to-chromium": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.2.7.tgz"
+			}
 		},
 		"buffer": {
 			"version": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
 			"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
 			"dev": true,
+			"requires": {
+				"base64-js": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+				"ieee754": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+				"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+			},
 			"dependencies": {
 				"isarray": {
 					"version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -710,7 +1172,11 @@
 		"camel-case": {
 			"version": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
 			"integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"no-case": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
+				"upper-case": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz"
+			}
 		},
 		"camelcase": {
 			"version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
@@ -721,6 +1187,10 @@
 			"version": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"dev": true,
+			"requires": {
+				"camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+				"map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+			},
 			"dependencies": {
 				"camelcase": {
 					"version": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
@@ -732,7 +1202,13 @@
 		"caniuse-api": {
 			"version": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.5.3.tgz",
 			"integrity": "sha1-UBjmdLUcOT5NUGFCddwBfifEoqI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.6.tgz",
+				"caniuse-db": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000639.tgz",
+				"lodash.memoize": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
+				"lodash.uniq": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
+			}
 		},
 		"caniuse-db": {
 			"version": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000639.tgz",
@@ -745,6 +1221,17 @@
 			"integrity": "sha1-MPJpXSoBoN/XeaJquD9NE0s9pcw=",
 			"dev": true
 		},
+		"canvas-prebuilt": {
+			"version": "1.6.5-prerelease.1",
+			"resolved": "https://registry.npmjs.org/canvas-prebuilt/-/canvas-prebuilt-1.6.5-prerelease.1.tgz",
+			"integrity": "sha1-aBSyC5yAg13MJL/WGZFHKIYwUhw=",
+			"dev": true,
+			"requires": {
+				"node-pre-gyp": "0.6.36",
+				"parse-css-font": "2.0.2",
+				"units-css": "0.4.0"
+			}
+		},
 		"caseless": {
 			"version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
 			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
@@ -753,47 +1240,92 @@
 		"center-align": {
 			"version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+				"lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+			}
 		},
 		"chai": {
 			"version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
 			"integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+				"deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+				"type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+			}
 		},
 		"chalk": {
 			"version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+				"escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+				"has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+				"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+				"supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+			}
 		},
 		"chokidar": {
 			"version": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
 			"integrity": "sha1-L0RHq16W5Q+z14n9kNTHLg5McMI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"anymatch": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+				"async-each": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+				"fsevents": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.1.tgz",
+				"glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"is-binary-path": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+				"is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+				"path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+				"readdirp": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
+			}
 		},
 		"cipher-base": {
 			"version": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
 			"integrity": "sha1-7qvxlEGc6QDaMBjCB9IS8qbfCgc=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+			}
 		},
 		"clap": {
 			"version": "https://registry.npmjs.org/clap/-/clap-1.1.3.tgz",
 			"integrity": "sha1-s7026T3Uy/s5WjwmiWNSRFJlwFs=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
+			}
 		},
 		"clean-css": {
 			"version": "https://registry.npmjs.org/clean-css/-/clean-css-4.0.9.tgz",
 			"integrity": "sha1-Y/9FCz+TlQjMDNKYm7nartyYMz4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+			}
 		},
 		"cli": {
 			"version": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
 			"integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"exit": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+				"glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+			}
 		},
 		"cliui": {
 			"version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+				"right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+				"wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+			}
 		},
 		"clone": {
 			"version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
@@ -808,7 +1340,10 @@
 		"coa": {
 			"version": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
 			"integrity": "sha1-f5WTRs/IcZ4/cjPNaFKFSnxn2KM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"q": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+			}
 		},
 		"code-point-at": {
 			"version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -818,12 +1353,20 @@
 		"color": {
 			"version": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
 			"integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+				"color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+				"color-string": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz"
+			}
 		},
 		"color-convert": {
 			"version": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
 			"integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz"
+			}
 		},
 		"color-name": {
 			"version": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz",
@@ -833,12 +1376,20 @@
 		"color-string": {
 			"version": "https://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
 			"integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.2.tgz"
+			}
 		},
 		"colormin": {
 			"version": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
 			"integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"color": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+				"css-color-names": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+				"has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz"
+			}
 		},
 		"colors": {
 			"version": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
@@ -848,12 +1399,18 @@
 		"combined-stream": {
 			"version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
 			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+			}
 		},
 		"commander": {
 			"version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
 			"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+			}
 		},
 		"commondir": {
 			"version": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -863,17 +1420,31 @@
 		"compressible": {
 			"version": "https://registry.npmjs.org/compressible/-/compressible-2.0.9.tgz",
 			"integrity": "sha1-baq04rWZwncN2eIeeokbHFp1VCU=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
+			}
 		},
 		"compression": {
 			"version": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
 			"integrity": "sha1-zOsSHsydCcUtetDDNQ6pPd1AK8M=",
 			"dev": true,
+			"requires": {
+				"accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+				"bytes": "https://registry.npmjs.org/bytes/-/bytes-2.3.0.tgz",
+				"compressible": "https://registry.npmjs.org/compressible/-/compressible-2.0.9.tgz",
+				"debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+				"on-headers": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+				"vary": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+			},
 			"dependencies": {
 				"debug": {
 					"version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
 					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+					}
 				},
 				"ms": {
 					"version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -895,7 +1466,10 @@
 		"console-browserify": {
 			"version": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
 			"integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"date-now": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+			}
 		},
 		"console-control-strings": {
 			"version": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -941,6 +1515,16 @@
 			"version": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-4.0.1.tgz",
 			"integrity": "sha1-lyjjg7lDFgUNDHRjlY8rhcCqggA=",
 			"dev": true,
+			"requires": {
+				"bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+				"fs-extra": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
+				"glob": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+				"is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+				"loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+				"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+				"minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+				"node-dir": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.16.tgz"
+			},
 			"dependencies": {
 				"bluebird": {
 					"version": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
@@ -950,7 +1534,14 @@
 				"glob": {
 					"version": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
 					"integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+						"once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+						"path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+					}
 				},
 				"is-extglob": {
 					"version": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -960,7 +1551,10 @@
 				"is-glob": {
 					"version": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+					}
 				}
 			}
 		},
@@ -978,6 +1572,14 @@
 			"version": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.1.tgz",
 			"integrity": "sha1-gX8sIDk0eh6b99CQwJI+U/dJyoI=",
 			"dev": true,
+			"requires": {
+				"js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+				"minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+				"parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+				"require-from-string": "https://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz"
+			},
 			"dependencies": {
 				"minimist": {
 					"version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -989,66 +1591,179 @@
 		"create-ecdh": {
 			"version": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
 			"integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+				"elliptic": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz"
+			}
 		},
 		"create-hash": {
 			"version": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
 			"integrity": "sha1-USEAYte7dHn2xlu0GpIgix1hq60=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"cipher-base": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.3.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"ripemd160": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
+				"sha.js": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
+			}
 		},
 		"create-hmac": {
 			"version": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
 			"integrity": "sha1-0/tLolPriz9W456i+8uK90e9MXA=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+			}
 		},
 		"cross-spawn": {
 			"version": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
 			"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"lru-cache": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
+				"which": "https://registry.npmjs.org/which/-/which-1.2.12.tgz"
+			}
 		},
 		"cryptiles": {
 			"version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 			"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+			}
 		},
 		"crypto-browserify": {
 			"version": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
 			"integrity": "sha1-NlKgkGq5sqfgw85mpAjpV6JIVSI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"browserify-cipher": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+				"browserify-sign": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.0.tgz",
+				"create-ecdh": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+				"create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+				"create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz",
+				"diffie-hellman": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"pbkdf2": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz",
+				"public-encrypt": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+				"randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
+			}
 		},
 		"css-color-names": {
 			"version": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
 			"integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
 			"dev": true
 		},
+		"css-font-size-keywords": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
+			"integrity": "sha1-hUh1rOmspqjS7g00WkSq6btttss=",
+			"dev": true
+		},
+		"css-font-stretch-keywords": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
+			"integrity": "sha1-UM7puboDH7XJUtRyMTnx4Qe1SxA=",
+			"dev": true
+		},
+		"css-font-style-keywords": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
+			"integrity": "sha1-XDUygT9jtKHelU0TzqhqtDM0CeQ=",
+			"dev": true
+		},
+		"css-font-weight-keywords": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
+			"integrity": "sha1-m8BGcayFvHJLV07106yWsNYE/Zc=",
+			"dev": true
+		},
+		"css-global-keywords": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
+			"integrity": "sha1-cqmupyeW0Bmx0qMlLeTlqqN+Smk=",
+			"dev": true
+		},
+		"css-list-helpers": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/css-list-helpers/-/css-list-helpers-1.0.1.tgz",
+			"integrity": "sha1-//VxkiAtuDJAxBaG+RnkSacCT30=",
+			"dev": true,
+			"requires": {
+				"tcomb": "2.7.0"
+			}
+		},
 		"css-loader": {
 			"version": "https://registry.npmjs.org/css-loader/-/css-loader-0.27.3.tgz",
 			"integrity": "sha1-aatvR7ab+xtazuYbrCqrFDAv8Nw=",
 			"dev": true,
+			"requires": {
+				"babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+				"css-selector-tokenizer": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+				"cssnano": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+				"loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+				"lodash.camelcase": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-modules-extract-imports": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.1.tgz",
+				"postcss-modules-local-by-default": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.1.1.tgz",
+				"postcss-modules-scope": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.2.tgz",
+				"postcss-modules-values": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.2.2.tgz",
+				"source-list-map": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
+			},
 			"dependencies": {
 				"loader-utils": {
 					"version": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+						"emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+						"json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+					}
 				}
 			}
 		},
 		"css-select": {
 			"version": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
 			"integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+				"css-what": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+				"domutils": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+				"nth-check": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
+			}
 		},
 		"css-selector-tokenizer": {
 			"version": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
 			"integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
 			"dev": true,
+			"requires": {
+				"cssesc": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+				"fastparse": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+				"regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz"
+			},
 			"dependencies": {
 				"regexpu-core": {
 					"version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
 					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+						"regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+						"regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+					}
 				}
 			}
+		},
+		"css-system-font-keywords": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
+			"integrity": "sha1-hcbwhquk6zLFcaMIav/ENLhII+0=",
+			"dev": true
 		},
 		"css-what": {
 			"version": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
@@ -1063,12 +1778,50 @@
 		"cssnano": {
 			"version": "https://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
 			"integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"autoprefixer": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+				"decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+				"defined": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+				"has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-calc": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+				"postcss-colormin": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+				"postcss-convert-values": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
+				"postcss-discard-comments": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
+				"postcss-discard-duplicates": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
+				"postcss-discard-empty": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
+				"postcss-discard-overridden": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
+				"postcss-discard-unused": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+				"postcss-filter-plugins": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+				"postcss-merge-idents": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
+				"postcss-merge-longhand": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
+				"postcss-merge-rules": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+				"postcss-minify-font-values": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
+				"postcss-minify-gradients": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
+				"postcss-minify-params": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+				"postcss-minify-selectors": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+				"postcss-normalize-charset": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
+				"postcss-normalize-url": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+				"postcss-ordered-values": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
+				"postcss-reduce-idents": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
+				"postcss-reduce-initial": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
+				"postcss-reduce-transforms": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
+				"postcss-svgo": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+				"postcss-unique-selectors": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+				"postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+				"postcss-zindex": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz"
+			}
 		},
 		"csso": {
 			"version": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
 			"integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"clap": "https://registry.npmjs.org/clap/-/clap-1.1.3.tgz",
+				"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+			}
 		},
 		"cssom": {
 			"version": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
@@ -1078,7 +1831,10 @@
 		"cssstyle": {
 			"version": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"cssom": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz"
+			}
 		},
 		"ctype": {
 			"version": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
@@ -1089,7 +1845,10 @@
 		"currently-unhandled": {
 			"version": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"array-find-index": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
+			}
 		},
 		"cycle": {
 			"version": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
@@ -1100,6 +1859,9 @@
 			"version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
+			"requires": {
+				"assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+			},
 			"dependencies": {
 				"assert-plus": {
 					"version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -1116,7 +1878,10 @@
 		"debug": {
 			"version": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
 			"integrity": "sha1-D364wwll7AjHKsz6ATDIt5mEFB0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+			}
 		},
 		"decamelize": {
 			"version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -1127,6 +1892,9 @@
 			"version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
 			"integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
 			"dev": true,
+			"requires": {
+				"type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+			},
 			"dependencies": {
 				"type-detect": {
 					"version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
@@ -1138,6 +1906,12 @@
 		"deep-equal": {
 			"version": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
 			"integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+			"dev": true
+		},
+		"deep-extend": {
+			"version": "0.4.2",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+			"integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
 			"dev": true
 		},
 		"deep-is": {
@@ -1153,7 +1927,16 @@
 		"del": {
 			"version": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"globby": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+				"is-path-cwd": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+				"is-path-in-cwd": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+				"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+				"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+			}
 		},
 		"delayed-stream": {
 			"version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1173,7 +1956,11 @@
 		"des.js": {
 			"version": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
 			"integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+			}
 		},
 		"destroy": {
 			"version": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
@@ -1183,12 +1970,20 @@
 		"detect-indent": {
 			"version": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+			}
 		},
 		"diffie-hellman": {
 			"version": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
 			"integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+				"miller-rabin": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+				"randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
+			}
 		},
 		"dns-equal": {
 			"version": "1.0.0",
@@ -1200,18 +1995,28 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.1.1.tgz",
 			"integrity": "sha1-I2nUUDivBF84mOb6VoYq7T9AKWw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"ip": "1.1.5",
+				"safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+			}
 		},
 		"dns-txt": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
 			"integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"buffer-indexof": "1.1.0"
+			}
 		},
 		"dom-converter": {
 			"version": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
 			"integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
 			"dev": true,
+			"requires": {
+				"utila": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz"
+			},
 			"dependencies": {
 				"utila": {
 					"version": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
@@ -1224,6 +2029,10 @@
 			"version": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
 			"integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
 			"dev": true,
+			"requires": {
+				"domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+				"entities": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+			},
 			"dependencies": {
 				"domelementtype": {
 					"version": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
@@ -1245,17 +2054,27 @@
 		"domhandler": {
 			"version": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
 			"integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+			}
 		},
 		"domutils": {
 			"version": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
 			"integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"dom-serializer": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+				"domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+			}
 		},
 		"du": {
 			"version": "https://registry.npmjs.org/du/-/du-0.1.0.tgz",
 			"integrity": "sha1-8m40CgnHvFtv1pr2263qYPqMb00=",
 			"dev": true,
+			"requires": {
+				"async": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+			},
 			"dependencies": {
 				"async": {
 					"version": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
@@ -1272,7 +2091,10 @@
 			"version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"requires": {
+				"jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+			}
 		},
 		"ee-first": {
 			"version": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1287,7 +2109,16 @@
 		"elliptic": {
 			"version": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
 			"integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+				"brorand": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+				"hash.js": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+				"hmac-drbg": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.0.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+				"minimalistic-crypto-utils": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+			}
 		},
 		"emojis-list": {
 			"version": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -1302,7 +2133,13 @@
 		"enhanced-resolve": {
 			"version": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz",
 			"integrity": "sha1-n0tib1dyRe3PSyrYPYbhf09CHew=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+				"memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"tapable": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz"
+			}
 		},
 		"entities": {
 			"version": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
@@ -1312,12 +2149,18 @@
 		"errno": {
 			"version": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
 			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"prr": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+			}
 		},
 		"error-ex": {
 			"version": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-arrayish": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+			}
 		},
 		"escape-html": {
 			"version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1333,12 +2176,22 @@
 			"version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
 			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
 			"dev": true,
+			"requires": {
+				"esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+				"estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+				"esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+				"optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+				"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+			},
 			"dependencies": {
 				"source-map": {
 					"version": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
 					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+					}
 				}
 			}
 		},
@@ -1374,12 +2227,18 @@
 		"eventsource": {
 			"version": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
 			"integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"original": "https://registry.npmjs.org/original/-/original-1.0.0.tgz"
+			}
 		},
 		"evp_bytestokey": {
 			"version": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
 			"integrity": "sha1-SXtmrZ/vZc18CKYYCCS6FHa2blM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz"
+			}
 		},
 		"exit": {
 			"version": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -1389,22 +2248,61 @@
 		"expand-brackets": {
 			"version": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-posix-bracket": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+			}
 		},
 		"expand-range": {
 			"version": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"fill-range": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+			}
 		},
 		"express": {
 			"version": "https://registry.npmjs.org/express/-/express-4.15.2.tgz",
 			"integrity": "sha1-rxB/wUhQRFfy3Kmm8lcdcSm5ezU=",
 			"dev": true,
+			"requires": {
+				"accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+				"array-flatten": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+				"content-disposition": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+				"content-type": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+				"cookie": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+				"cookie-signature": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+				"debug": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
+				"depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+				"encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+				"escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+				"etag": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+				"finalhandler": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.0.tgz",
+				"fresh": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+				"merge-descriptors": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+				"methods": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+				"on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+				"parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+				"path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+				"proxy-addr": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.3.tgz",
+				"qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+				"range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+				"send": "https://registry.npmjs.org/send/-/send-0.15.1.tgz",
+				"serve-static": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.1.tgz",
+				"setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+				"statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+				"type-is": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
+				"utils-merge": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+				"vary": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz"
+			},
 			"dependencies": {
 				"debug": {
 					"version": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
 					"integrity": "sha1-eYVQkLosTjEVzH2HaUkdWPBJE1E=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+					}
 				}
 			}
 		},
@@ -1416,19 +2314,33 @@
 		"extglob": {
 			"version": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+			}
 		},
 		"extract-text-webpack-plugin": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-2.1.2.tgz",
 			"integrity": "sha1-dW7076gVXDaBgz+8NNpTuUF0bWw=",
 			"dev": true,
+			"requires": {
+				"async": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+				"loader-utils": "1.1.0",
+				"schema-utils": "0.3.0",
+				"webpack-sources": "1.0.1"
+			},
 			"dependencies": {
 				"loader-utils": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+						"emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+						"json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+					}
 				},
 				"source-list-map": {
 					"version": "2.0.0",
@@ -1440,7 +2352,11 @@
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
 					"integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"source-list-map": "2.0.0",
+						"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+					}
 				}
 			}
 		},
@@ -1473,7 +2389,10 @@
 		"faye-websocket": {
 			"version": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
 			"integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"websocket-driver": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
+			}
 		},
 		"filbert": {
 			"version": "https://registry.npmjs.org/filbert/-/filbert-0.1.20.tgz",
@@ -1483,11 +2402,19 @@
 			"version": "https://registry.npmjs.org/file-loader/-/file-loader-0.10.1.tgz",
 			"integrity": "sha1-gVA0EZiR/GRB+1pkwRvJPCLd2EI=",
 			"dev": true,
+			"requires": {
+				"loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz"
+			},
 			"dependencies": {
 				"loader-utils": {
 					"version": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+						"emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+						"json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+					}
 				}
 			}
 		},
@@ -1499,12 +2426,23 @@
 		"fill-keys": {
 			"version": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
 			"integrity": "sha1-mo+jb06K1jTjv2tPPIiCVRRS6yA=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-object": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+				"merge-descriptors": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+			}
 		},
 		"fill-range": {
 			"version": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 			"dev": true,
+			"requires": {
+				"is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+				"isobject": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+				"randomatic": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
+				"repeat-element": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+				"repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+			},
 			"dependencies": {
 				"isarray": {
 					"version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -1514,7 +2452,10 @@
 				"isobject": {
 					"version": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
 					"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+					}
 				}
 			}
 		},
@@ -1522,23 +2463,44 @@
 			"version": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.0.tgz",
 			"integrity": "sha1-tWkcLAkSCS8YrCPpQWveXNfcZ1U=",
 			"dev": true,
+			"requires": {
+				"debug": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
+				"encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+				"escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+				"on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+				"parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+				"statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+				"unpipe": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+			},
 			"dependencies": {
 				"debug": {
 					"version": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
 					"integrity": "sha1-eYVQkLosTjEVzH2HaUkdWPBJE1E=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+					}
 				}
 			}
 		},
 		"find-cache-dir": {
 			"version": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
 			"integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"commondir": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+				"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+				"pkg-dir": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
+			}
 		},
 		"find-up": {
 			"version": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"path-exists": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+				"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+			}
 		},
 		"flatten": {
 			"version": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
@@ -1553,7 +2515,10 @@
 		"for-own": {
 			"version": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+			}
 		},
 		"forever-agent": {
 			"version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -1563,12 +2528,20 @@
 		"form-data": {
 			"version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
 			"integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+				"combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+				"mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz"
+			}
 		},
 		"formatio": {
 			"version": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
 			"integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"samsam": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz"
+			}
 		},
 		"forwarded": {
 			"version": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
@@ -1583,7 +2556,14 @@
 		"fs-extra": {
 			"version": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
 			"integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+				"jsonfile": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+				"klaw": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+				"path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+				"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+			}
 		},
 		"fs.realpath": {
 			"version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1595,6 +2575,10 @@
 			"integrity": "sha1-8Z/Sj0Pur3YWgOUZogPE0LPTGv8=",
 			"dev": true,
 			"optional": true,
+			"requires": {
+				"nan": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
+				"node-pre-gyp": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz"
+			},
 			"dependencies": {
 				"abbrev": {
 					"version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
@@ -1623,7 +2607,11 @@
 					"version": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
 					"integrity": "sha1-gORw6VoIR5T+GJkmLFZnxuiN4bM=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"delegates": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+						"readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz"
+					}
 				},
 				"asn1": {
 					"version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -1664,22 +2652,35 @@
 					"version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 					"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+					}
 				},
 				"block-stream": {
 					"version": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
 					"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+					}
 				},
 				"boom": {
 					"version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
 					"integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+					}
 				},
 				"brace-expansion": {
 					"version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
 					"integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+						"concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+					}
 				},
 				"buffer-shims": {
 					"version": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
@@ -1696,7 +2697,14 @@
 					"version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+						"escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+						"has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+						"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+						"supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+					}
 				},
 				"code-point-at": {
 					"version": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
@@ -1706,13 +2714,19 @@
 				"combined-stream": {
 					"version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
 					"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+					}
 				},
 				"commander": {
 					"version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
 					"integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+					}
 				},
 				"concat-map": {
 					"version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1733,13 +2747,19 @@
 					"version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
 					"integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+					}
 				},
 				"dashdash": {
 					"version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 					"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 					"dev": true,
 					"optional": true,
+					"requires": {
+						"assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+					},
 					"dependencies": {
 						"assert-plus": {
 							"version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -1753,7 +2773,10 @@
 					"version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
 					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+					}
 				},
 				"deep-extend": {
 					"version": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
@@ -1776,7 +2799,10 @@
 					"version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
 					"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+					}
 				},
 				"escape-string-regexp": {
 					"version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1805,7 +2831,12 @@
 					"version": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
 					"integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+						"combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+						"mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz"
+					}
 				},
 				"fs.realpath": {
 					"version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1815,19 +2846,40 @@
 				"fstream": {
 					"version": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
 					"integrity": "sha1-YE6Kkv4m/9n2+uMDmdSYThqyKCI=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+						"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz"
+					}
 				},
 				"fstream-ignore": {
 					"version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
 					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+					}
 				},
 				"gauge": {
 					"version": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
 					"integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"aproba": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+						"console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+						"has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+						"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+						"signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+						"string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+						"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+						"wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+					}
 				},
 				"generate-function": {
 					"version": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
@@ -1839,13 +2891,19 @@
 					"version": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
 					"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"is-property": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+					}
 				},
 				"getpass": {
 					"version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
 					"integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
 					"dev": true,
 					"optional": true,
+					"requires": {
+						"assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+					},
 					"dependencies": {
 						"assert-plus": {
 							"version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -1858,7 +2916,15 @@
 				"glob": {
 					"version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
 					"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+						"inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+						"once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+						"path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+					}
 				},
 				"graceful-fs": {
 					"version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -1875,13 +2941,22 @@
 					"version": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
 					"integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+						"commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+						"is-my-json-valid": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+						"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+					}
 				},
 				"has-ansi": {
 					"version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 					"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+					}
 				},
 				"has-unicode": {
 					"version": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
@@ -1893,7 +2968,13 @@
 					"version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 					"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+						"cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+						"hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+						"sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+					}
 				},
 				"hoek": {
 					"version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
@@ -1904,12 +2985,21 @@
 					"version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
 					"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+						"jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+						"sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz"
+					}
 				},
 				"inflight": {
 					"version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+						"wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+					}
 				},
 				"inherits": {
 					"version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -1925,13 +3015,22 @@
 				"is-fullwidth-code-point": {
 					"version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+					}
 				},
 				"is-my-json-valid": {
 					"version": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
 					"integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"generate-function": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+						"generate-object-property": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+						"jsonpointer": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+						"xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+					}
 				},
 				"is-property": {
 					"version": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
@@ -1960,7 +3059,10 @@
 					"version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
 					"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+					}
 				},
 				"jsbn": {
 					"version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -1990,7 +3092,12 @@
 					"version": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
 					"integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+						"json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+						"verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+					}
 				},
 				"mime-db": {
 					"version": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
@@ -2000,12 +3107,18 @@
 				"mime-types": {
 					"version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
 					"integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
+					}
 				},
 				"minimatch": {
 					"version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 					"integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+					}
 				},
 				"minimist": {
 					"version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -2015,7 +3128,10 @@
 				"mkdirp": {
 					"version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+					}
 				},
 				"ms": {
 					"version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -2027,19 +3143,39 @@
 					"version": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.33.tgz",
 					"integrity": "sha1-ZArFUZj2qSWXLgwWxKwmoDTV7Mk=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+						"nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+						"npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+						"rc": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
+						"request": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
+						"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+						"semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+						"tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+						"tar-pack": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz"
+					}
 				},
 				"nopt": {
 					"version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 					"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+					}
 				},
 				"npmlog": {
 					"version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
 					"integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+						"console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+						"gauge": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
+						"set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+					}
 				},
 				"number-is-nan": {
 					"version": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -2061,7 +3197,10 @@
 				"once": {
 					"version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+					}
 				},
 				"path-is-absolute": {
 					"version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2078,7 +3217,10 @@
 					"version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 					"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+					}
 				},
 				"process-nextick-args": {
 					"version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -2102,6 +3244,12 @@
 					"integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
 					"dev": true,
 					"optional": true,
+					"requires": {
+						"deep-extend": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.1.tgz",
+						"ini": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+						"minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+						"strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+					},
 					"dependencies": {
 						"minimist": {
 							"version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -2115,18 +3263,52 @@
 					"version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.2.tgz",
 					"integrity": "sha1-qeb+w8fdqF+LsbO6cChgRVb8gl4=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+						"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+						"process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+						"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+						"util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+					}
 				},
 				"request": {
 					"version": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
 					"integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+						"aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+						"caseless": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+						"combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+						"extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+						"forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+						"form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+						"har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+						"hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+						"http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+						"is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+						"isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+						"json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+						"mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+						"oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+						"qs": "https://registry.npmjs.org/qs/-/qs-6.3.1.tgz",
+						"stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+						"tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+						"tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+						"uuid": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+					}
 				},
 				"rimraf": {
 					"version": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
 					"integrity": "sha1-loAAk8vxoMhr2VtGJUZ1NcKd+gQ=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+					}
 				},
 				"semver": {
 					"version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -2150,13 +3332,27 @@
 					"version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 					"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+					}
 				},
 				"sshpk": {
 					"version": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
 					"integrity": "sha1-1agEziJpVRVjjnmNviMnPeBwpfo=",
 					"dev": true,
 					"optional": true,
+					"requires": {
+						"asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+						"assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+						"bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+						"dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+						"ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+						"getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+						"jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+						"jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+						"tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+					},
 					"dependencies": {
 						"assert-plus": {
 							"version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2174,7 +3370,12 @@
 				"string-width": {
 					"version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+						"is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+						"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+					}
 				},
 				"stringstream": {
 					"version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -2185,7 +3386,10 @@
 				"strip-ansi": {
 					"version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+					}
 				},
 				"strip-json-comments": {
 					"version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -2202,25 +3406,52 @@
 				"tar": {
 					"version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 					"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+						"fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+					}
 				},
 				"tar-pack": {
 					"version": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.3.0.tgz",
 					"integrity": "sha1-MJMYFkGPVa/E0hd1r91nIM7kXa4=",
 					"dev": true,
 					"optional": true,
+					"requires": {
+						"debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+						"fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.10.tgz",
+						"fstream-ignore": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+						"once": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+						"readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+						"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.5.4.tgz",
+						"tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+						"uid-number": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+					},
 					"dependencies": {
 						"once": {
 							"version": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
 							"integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
 							"dev": true,
-							"optional": true
+							"optional": true,
+							"requires": {
+								"wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+							}
 						},
 						"readable-stream": {
 							"version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
 							"integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
 							"dev": true,
-							"optional": true
+							"optional": true,
+							"requires": {
+								"buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+								"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+								"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+								"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+								"process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+								"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+								"util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+							}
 						}
 					}
 				},
@@ -2228,7 +3459,10 @@
 					"version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
 					"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+					}
 				},
 				"tunnel-agent": {
 					"version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
@@ -2263,13 +3497,19 @@
 					"version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
 					"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+					}
 				},
 				"wide-align": {
 					"version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
 					"integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+					}
 				},
 				"wrappy": {
 					"version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -2287,17 +3527,31 @@
 		"fstream": {
 			"version": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+				"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+			}
 		},
 		"fstream-ignore": {
 			"version": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
 			"integrity": "sha1-GMiR2wG3gqdKe/+Tag8kmXdBx6s=",
 			"dev": true,
+			"requires": {
+				"fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
+			},
 			"dependencies": {
 				"minimatch": {
 					"version": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 					"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+					}
 				}
 			}
 		},
@@ -2309,12 +3563,25 @@
 		"gauge": {
 			"version": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
 			"integrity": "sha1-HCOFX5YvF7OtPQ3HRD8wRULt/gk=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"aproba": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+				"console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+				"has-unicode": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+				"string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+				"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+				"wide-align": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz"
+			}
 		},
 		"gaze": {
 			"version": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
 			"integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"globule": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz"
+			}
 		},
 		"get-caller-file": {
 			"version": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
@@ -2330,6 +3597,9 @@
 			"version": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
 			"integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
 			"dev": true,
+			"requires": {
+				"assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+			},
 			"dependencies": {
 				"assert-plus": {
 					"version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2341,17 +3611,32 @@
 		"glob": {
 			"version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
 			"integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+				"inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+				"once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+				"path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+			}
 		},
 		"glob-base": {
 			"version": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"glob-parent": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+				"is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+			}
 		},
 		"glob-parent": {
 			"version": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+			}
 		},
 		"globals": {
 			"version": "https://registry.npmjs.org/globals/-/globals-9.16.0.tgz",
@@ -2361,12 +3646,25 @@
 		"globby": {
 			"version": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+				"arrify": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+				"glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+				"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+			}
 		},
 		"globule": {
 			"version": "https://registry.npmjs.org/globule/-/globule-1.1.0.tgz",
 			"integrity": "sha1-xJNS5NwYPYWJPuglOF65lLtt9F8=",
 			"dev": true,
+			"requires": {
+				"glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+				"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
+				"minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+			},
 			"dependencies": {
 				"lodash": {
 					"version": "https://registry.npmjs.org/lodash/-/lodash-4.16.6.tgz",
@@ -2403,17 +3701,27 @@
 		"har-validator": {
 			"version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
 			"integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
+				"har-schema": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+			}
 		},
 		"has": {
 			"version": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"function-bind": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+			}
 		},
 		"has-ansi": {
 			"version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+			}
 		},
 		"has-flag": {
 			"version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -2428,12 +3736,21 @@
 		"hash.js": {
 			"version": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
 			"integrity": "sha1-EzL/ABVsCg/92CNgE9B7d6BFFXM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+			}
 		},
 		"hawk": {
 			"version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
 			"integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+				"cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+				"hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+				"sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+			}
 		},
 		"he": {
 			"version": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
@@ -2443,7 +3760,12 @@
 		"hmac-drbg": {
 			"version": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.0.tgz",
 			"integrity": "sha1-PbRx9FquSplKBogyIXH1G4uRvuU=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"hash.js": "https://registry.npmjs.org/hash.js/-/hash.js-1.0.3.tgz",
+				"minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+				"minimalistic-crypto-utils": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz"
+			}
 		},
 		"hoek": {
 			"version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
@@ -2453,7 +3775,11 @@
 		"home-or-tmp": {
 			"version": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+				"os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+			}
 		},
 		"hosted-git-info": {
 			"version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.3.1.tgz",
@@ -2464,6 +3790,12 @@
 			"version": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
 			"integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
 			"dev": true,
+			"requires": {
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"obuf": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
+				"readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+				"wbuf": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz"
+			},
 			"dependencies": {
 				"isarray": {
 					"version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2473,7 +3805,16 @@
 				"readable-stream": {
 					"version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
 					"integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+						"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+						"process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+						"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+						"util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+					}
 				}
 			}
 		},
@@ -2485,7 +3826,10 @@
 		"html-encoding-sniffer": {
 			"version": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
 			"integrity": "sha1-eb96eF6klf5mFl5zQVPzY/9UN9o=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"whatwg-encoding": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz"
+			}
 		},
 		"html-entities": {
 			"version": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.0.tgz",
@@ -2495,23 +3839,50 @@
 		"html-minifier": {
 			"version": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.4.2.tgz",
 			"integrity": "sha1-MYlrqvc1wdlfegtykfncNsByB1I=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"camel-case": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+				"clean-css": "https://registry.npmjs.org/clean-css/-/clean-css-4.0.9.tgz",
+				"commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+				"he": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+				"ncname": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
+				"param-case": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+				"relateurl": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+				"uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.14.tgz"
+			}
 		},
 		"html-webpack-plugin": {
 			"version": "2.29.0",
 			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-2.29.0.tgz",
 			"integrity": "sha1-6Yf0IYU9O2k4yMTIFxhC5f0XryM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"bluebird": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+				"html-minifier": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.4.2.tgz",
+				"loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+				"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+				"pretty-error": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.0.3.tgz",
+				"toposort": "https://registry.npmjs.org/toposort/-/toposort-1.0.3.tgz"
+			}
 		},
 		"htmlparser2": {
 			"version": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
 			"integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
 			"dev": true,
+			"requires": {
+				"domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+				"domhandler": "https://registry.npmjs.org/domhandler/-/domhandler-2.1.0.tgz",
+				"domutils": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
+				"readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz"
+			},
 			"dependencies": {
 				"domutils": {
 					"version": "https://registry.npmjs.org/domutils/-/domutils-1.1.6.tgz",
 					"integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+					}
 				}
 			}
 		},
@@ -2523,12 +3894,22 @@
 		"http-errors": {
 			"version": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
 			"integrity": "sha1-X4uO2YrKVFZWv1cplzh/kEpyIlc=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+				"statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+			}
 		},
 		"http-proxy": {
 			"version": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
 			"integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
 			"dev": true,
+			"requires": {
+				"eventemitter3": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+				"requires-port": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+			},
 			"dependencies": {
 				"eventemitter3": {
 					"version": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
@@ -2541,6 +3922,12 @@
 			"version": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
 			"integrity": "sha1-ZC6ISIUdZvCdTxJJEoRtuutBuDM=",
 			"dev": true,
+			"requires": {
+				"http-proxy": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+				"is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+				"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+				"micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+			},
 			"dependencies": {
 				"is-extglob": {
 					"version": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2550,14 +3937,22 @@
 				"is-glob": {
 					"version": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 					"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+					}
 				}
 			}
 		},
 		"http-signature": {
 			"version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
 			"integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+				"jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+				"sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz"
+			}
 		},
 		"https-browserify": {
 			"version": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
@@ -2592,7 +3987,10 @@
 		"indent-string": {
 			"version": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"repeating": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+			}
 		},
 		"indexes-of": {
 			"version": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
@@ -2607,18 +4005,31 @@
 		"inflight": {
 			"version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+				"wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+			}
 		},
 		"inherits": {
 			"version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 			"dev": true
 		},
+		"ini": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+			"integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+			"dev": true
+		},
 		"internal-ip": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-1.2.0.tgz",
 			"integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz"
+			}
 		},
 		"interpret": {
 			"version": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
@@ -2628,7 +4039,10 @@
 		"invariant": {
 			"version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"loose-envify": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+			}
 		},
 		"invert-kv": {
 			"version": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
@@ -2659,7 +4073,10 @@
 		"is-binary-path": {
 			"version": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"binary-extensions": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz"
+			}
 		},
 		"is-buffer": {
 			"version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
@@ -2669,7 +4086,10 @@
 		"is-builtin-module": {
 			"version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"builtin-modules": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+			}
 		},
 		"is-domain": {
 			"version": "https://registry.npmjs.org/is-domain/-/is-domain-0.0.1.tgz",
@@ -2684,7 +4104,10 @@
 		"is-equal-shallow": {
 			"version": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+			}
 		},
 		"is-extendable": {
 			"version": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -2699,22 +4122,34 @@
 		"is-finite": {
 			"version": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+			}
 		},
 		"is-fullwidth-code-point": {
 			"version": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"number-is-nan": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+			}
 		},
 		"is-glob": {
 			"version": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+			}
 		},
 		"is-number": {
 			"version": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz"
+			}
 		},
 		"is-object": {
 			"version": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
@@ -2729,12 +4164,18 @@
 		"is-path-in-cwd": {
 			"version": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
 			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-path-inside": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+			}
 		},
 		"is-path-inside": {
 			"version": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
 			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"path-is-inside": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+			}
 		},
 		"is-plain-obj": {
 			"version": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -2744,7 +4185,10 @@
 		"is-plain-object": {
 			"version": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.1.tgz",
 			"integrity": "sha1-TXylObydubc3uKy2EvIxjvkvKU8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"isobject": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz"
+			}
 		},
 		"is-posix-bracket": {
 			"version": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
@@ -2759,7 +4203,10 @@
 		"is-svg": {
 			"version": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
 			"integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"html-comment-regex": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz"
+			}
 		},
 		"is-typedarray": {
 			"version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -2785,6 +4232,12 @@
 			"version": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-0.4.1.tgz",
 			"integrity": "sha1-Gl8SbHD+05yT2jgPpiy65XI+fcI="
 		},
+		"isnumeric": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/isnumeric/-/isnumeric-0.2.0.tgz",
+			"integrity": "sha1-ojR7o2DeGeM9D/1ZD933dVy/LmQ=",
+			"dev": true
+		},
 		"isobject": {
 			"version": "https://registry.npmjs.org/isobject/-/isobject-1.0.2.tgz",
 			"integrity": "sha1-8Pm4zpLdVA+gdAiC44NaLgIux4o=",
@@ -2799,7 +4252,10 @@
 			"version": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
 			"integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
 			"dev": true,
-			"optional": true
+			"optional": true,
+			"requires": {
+				"jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+			}
 		},
 		"js-base64": {
 			"version": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
@@ -2814,7 +4270,11 @@
 		"js-yaml": {
 			"version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
 			"integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+				"esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+			}
 		},
 		"jsbn": {
 			"version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -2825,7 +4285,28 @@
 		"jsdom": {
 			"version": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
 			"integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"abab": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
+				"acorn": "https://registry.npmjs.org/acorn/-/acorn-4.0.11.tgz",
+				"acorn-globals": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+				"array-equal": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+				"content-type-parser": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
+				"cssom": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+				"cssstyle": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+				"escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+				"html-encoding-sniffer": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
+				"nwmatcher": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.3.9.tgz",
+				"parse5": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+				"request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+				"sax": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz",
+				"symbol-tree": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+				"tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+				"webidl-conversions": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
+				"whatwg-encoding": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
+				"whatwg-url": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.7.0.tgz",
+				"xml-name-validator": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
+			}
 		},
 		"jsdom-global": {
 			"version": "https://registry.npmjs.org/jsdom-global/-/jsdom-global-2.1.1.tgz",
@@ -2842,12 +4323,25 @@
 			"resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
 			"integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
 			"dev": true,
+			"requires": {
+				"cli": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+				"console-browserify": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+				"exit": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+				"htmlparser2": "3.8.3",
+				"lodash": "3.7.0",
+				"minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+				"shelljs": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+				"strip-json-comments": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz"
+			},
 			"dependencies": {
 				"domhandler": {
 					"version": "2.3.0",
 					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
 					"integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+					}
 				},
 				"entities": {
 					"version": "1.0.0",
@@ -2859,7 +4353,14 @@
 					"version": "3.8.3",
 					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
 					"integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"domelementtype": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+						"domhandler": "2.3.0",
+						"domutils": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+						"entities": "1.0.0",
+						"readable-stream": "1.1.14"
+					}
 				},
 				"lodash": {
 					"version": "3.7.0",
@@ -2871,7 +4372,13 @@
 					"version": "1.1.14",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+						"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+					}
 				}
 			}
 		},
@@ -2894,7 +4401,10 @@
 		"json-stable-stringify": {
 			"version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+			}
 		},
 		"json-stringify-safe": {
 			"version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -2913,7 +4423,10 @@
 		"jsonfile": {
 			"version": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
 			"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+			}
 		},
 		"jsonify": {
 			"version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
@@ -2924,6 +4437,12 @@
 			"version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
 			"integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
 			"dev": true,
+			"requires": {
+				"assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+				"extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+				"json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+				"verror": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+			},
 			"dependencies": {
 				"assert-plus": {
 					"version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -2940,12 +4459,18 @@
 		"kind-of": {
 			"version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
 			"integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+			}
 		},
 		"klaw": {
 			"version": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
 			"integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+			}
 		},
 		"lazy-cache": {
 			"version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -2955,17 +4480,31 @@
 		"lcid": {
 			"version": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"invert-kv": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+			}
 		},
 		"levn": {
 			"version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+				"type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+			}
 		},
 		"load-json-file": {
 			"version": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+				"parse-json": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+				"pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+				"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+				"strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+			}
 		},
 		"loader-runner": {
 			"version": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
@@ -2975,7 +4514,13 @@
 		"loader-utils": {
 			"version": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
 			"integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+				"emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+				"json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+			}
 		},
 		"lodash": {
 			"version": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
@@ -2985,7 +4530,11 @@
 		"lodash._baseassign": {
 			"version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
 			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+				"lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+			}
 		},
 		"lodash._basecopy": {
 			"version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
@@ -3025,7 +4574,12 @@
 		"lodash.create": {
 			"version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
 			"integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+				"lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+				"lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+			}
 		},
 		"lodash.isarguments": {
 			"version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -3040,7 +4594,12 @@
 		"lodash.keys": {
 			"version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+				"lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+				"lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+			}
 		},
 		"lodash.memoize": {
 			"version": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -3075,12 +4634,19 @@
 		"loose-envify": {
 			"version": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"js-tokens": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz"
+			}
 		},
 		"loud-rejection": {
 			"version": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"currently-unhandled": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+				"signal-exit": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+			}
 		},
 		"lower-case": {
 			"version": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
@@ -3090,7 +4656,11 @@
 		"lru-cache": {
 			"version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.2.tgz",
 			"integrity": "sha1-HRdnnAac2l0ECZGgnbwsDbN35V4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+				"yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+			}
 		},
 		"macaddress": {
 			"version": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
@@ -3116,6 +4686,10 @@
 			"version": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
 			"integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
 			"dev": true,
+			"requires": {
+				"errno": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+				"readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz"
+			},
 			"dependencies": {
 				"isarray": {
 					"version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3125,7 +4699,16 @@
 				"readable-stream": {
 					"version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
 					"integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+						"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+						"process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+						"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+						"util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+					}
 				}
 			}
 		},
@@ -3133,6 +4716,18 @@
 			"version": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"dev": true,
+			"requires": {
+				"camelcase-keys": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+				"decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+				"loud-rejection": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+				"map-obj": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+				"minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+				"normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+				"redent": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+				"trim-newlines": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+			},
 			"dependencies": {
 				"minimist": {
 					"version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
@@ -3154,12 +4749,31 @@
 		"micromatch": {
 			"version": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"arr-diff": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+				"array-unique": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+				"braces": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+				"expand-brackets": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+				"extglob": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+				"filename-regex": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz",
+				"is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+				"is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+				"kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+				"normalize-path": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
+				"object.omit": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+				"parse-glob": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+				"regex-cache": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+			}
 		},
 		"miller-rabin": {
 			"version": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
 			"integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+				"brorand": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz"
+			}
 		},
 		"mime": {
 			"version": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
@@ -3175,7 +4789,10 @@
 		"mime-types": {
 			"version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
 			"integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
+			}
 		},
 		"mini-signals": {
 			"version": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.1.1.tgz",
@@ -3194,7 +4811,10 @@
 		"minimatch": {
 			"version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
 			"integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+			}
 		},
 		"minimist": {
 			"version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
@@ -3205,6 +4825,10 @@
 			"version": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
 			"integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
 			"dev": true,
+			"requires": {
+				"for-in": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
+				"is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+			},
 			"dependencies": {
 				"for-in": {
 					"version": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
@@ -3216,19 +4840,38 @@
 		"mkdirp": {
 			"version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+			}
 		},
 		"mocha": {
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
 			"integrity": "sha1-0O9NMyEm2/GNDWQMmzgt1IvpdZQ=",
 			"dev": true,
+			"requires": {
+				"browser-stdout": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+				"commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+				"debug": "2.6.0",
+				"diff": "3.2.0",
+				"escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+				"glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+				"growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+				"json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+				"lodash.create": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+				"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+				"supports-color": "3.1.2"
+			},
 			"dependencies": {
 				"debug": {
 					"version": "2.6.0",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
 					"integrity": "sha1-vFlryr52F/Edn6FTYe3tVgi4SZs=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+					}
 				},
 				"diff": {
 					"version": "3.2.0",
@@ -3240,7 +4883,10 @@
 					"version": "3.1.2",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
 					"integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+					}
 				}
 			}
 		},
@@ -3263,7 +4909,11 @@
 			"version": "6.1.1",
 			"resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.1.1.tgz",
 			"integrity": "sha1-bn3oalcIcqsXBYrepxYLvsqBTd4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"dns-packet": "1.1.1",
+				"thunky": "0.1.0"
+			}
 		},
 		"multicast-dns-service-types": {
 			"version": "1.1.0",
@@ -3294,7 +4944,10 @@
 		"ncname": {
 			"version": "https://registry.npmjs.org/ncname/-/ncname-1.0.0.tgz",
 			"integrity": "sha1-W1etGLHKCShk72Kwse2BlPODtxw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"xml-char-classes": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz"
+			}
 		},
 		"ncp": {
 			"version": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
@@ -3314,12 +4967,18 @@
 		"no-case": {
 			"version": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz",
 			"integrity": "sha1-euuhxzpSGEJlVUt9wDuvcg34AIE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"lower-case": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz"
+			}
 		},
 		"node-dir": {
 			"version": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.16.tgz",
 			"integrity": "sha1-0u9YOqULkNk9uM3Sb86lg1OVf+Q=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+			}
 		},
 		"node-forge": {
 			"version": "0.6.33",
@@ -3330,12 +4989,52 @@
 		"node-gyp": {
 			"version": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.0.tgz",
 			"integrity": "sha1-dHT2OjoFARYd2gtjQfAi8UxCP6Y=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+				"glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+				"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+				"minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+				"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+				"nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+				"npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+				"osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+				"request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+				"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+				"semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+				"tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+				"which": "https://registry.npmjs.org/which/-/which-1.2.12.tgz"
+			}
 		},
 		"node-libs-browser": {
 			"version": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
 			"integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
 			"dev": true,
+			"requires": {
+				"assert": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+				"browserify-zlib": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+				"buffer": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+				"console-browserify": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+				"constants-browserify": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+				"crypto-browserify": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.0.tgz",
+				"domain-browser": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+				"events": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+				"https-browserify": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+				"os-browserify": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+				"path-browserify": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+				"process": "https://registry.npmjs.org/process/-/process-0.11.9.tgz",
+				"punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+				"querystring-es3": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+				"readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+				"stream-browserify": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+				"stream-http": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.3.tgz",
+				"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+				"timers-browserify": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
+				"tty-browserify": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+				"url": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+				"util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+				"vm-browserify": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+			},
 			"dependencies": {
 				"isarray": {
 					"version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -3345,7 +5044,45 @@
 				"readable-stream": {
 					"version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
 					"integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+						"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+						"process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+						"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+						"util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+					}
+				}
+			}
+		},
+		"node-pre-gyp": {
+			"version": "0.6.36",
+			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+			"integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
+			"dev": true,
+			"requires": {
+				"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+				"nopt": "4.0.1",
+				"npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+				"rc": "1.2.1",
+				"request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+				"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+				"semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+				"tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+				"tar-pack": "3.4.0"
+			},
+			"dependencies": {
+				"nopt": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
+					"dev": true,
+					"requires": {
+						"abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+						"osenv": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
+					}
 				}
 			}
 		},
@@ -3353,17 +5090,46 @@
 			"version": "4.5.3",
 			"resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.5.3.tgz",
 			"integrity": "sha1-0JydEXlkEjnRuX/8YjH9zsU+FWg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"async-foreach": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
+				"chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+				"cross-spawn": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+				"gaze": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+				"get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+				"glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+				"in-publish": "https://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz",
+				"lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+				"lodash.clonedeep": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+				"lodash.mergewith": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.0.tgz",
+				"meow": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+				"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+				"nan": "https://registry.npmjs.org/nan/-/nan-2.5.1.tgz",
+				"node-gyp": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.0.tgz",
+				"npmlog": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
+				"request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+				"sass-graph": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.2.tgz",
+				"stdout-stream": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz"
+			}
 		},
 		"nopt": {
 			"version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+			}
 		},
 		"normalize-package-data": {
 			"version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
 			"integrity": "sha1-SY+kIMlkAfeHQCuiHmAN75+YH/8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.3.1.tgz",
+				"is-builtin-module": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+				"semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+				"validate-npm-package-license": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+			}
 		},
 		"normalize-path": {
 			"version": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.0.1.tgz",
@@ -3378,17 +5144,32 @@
 		"normalize-url": {
 			"version": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
 			"integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"prepend-http": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+				"query-string": "https://registry.npmjs.org/query-string/-/query-string-4.3.2.tgz",
+				"sort-keys": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz"
+			}
 		},
 		"npmlog": {
 			"version": "https://registry.npmjs.org/npmlog/-/npmlog-4.0.2.tgz",
 			"integrity": "sha1-0DlQ4OeM4VJ7om0qdZLpNIrD518=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"are-we-there-yet": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.2.tgz",
+				"console-control-strings": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+				"gauge": "https://registry.npmjs.org/gauge/-/gauge-2.7.3.tgz",
+				"set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+			}
 		},
 		"nth-check": {
 			"version": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
 			"integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"boolbase": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+			}
 		},
 		"num2fraction": {
 			"version": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
@@ -3417,7 +5198,11 @@
 		"object.omit": {
 			"version": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"for-own": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+				"is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+			}
 		},
 		"obuf": {
 			"version": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
@@ -3427,7 +5212,10 @@
 		"on-finished": {
 			"version": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
 			"integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"ee-first": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+			}
 		},
 		"on-headers": {
 			"version": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
@@ -3437,17 +5225,32 @@
 		"once": {
 			"version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+			}
 		},
 		"opn": {
 			"version": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
 			"integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+			}
 		},
 		"optionator": {
 			"version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
+			"requires": {
+				"deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+				"fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+				"levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+				"prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+				"type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+				"wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+			},
 			"dependencies": {
 				"wordwrap": {
 					"version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
@@ -3460,11 +5263,18 @@
 			"version": "https://registry.npmjs.org/original/-/original-1.0.0.tgz",
 			"integrity": "sha1-kUf5P6FpbQS+YeAb1QuurKZWvTs=",
 			"dev": true,
+			"requires": {
+				"url-parse": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz"
+			},
 			"dependencies": {
 				"url-parse": {
 					"version": "https://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
 					"integrity": "sha1-CFSGBCKv3P7+tsllxmLUgAFpkns=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"querystringify": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+						"requires-port": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+					}
 				}
 			}
 		},
@@ -3481,7 +5291,10 @@
 		"os-locale": {
 			"version": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"lcid": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+			}
 		},
 		"os-tmpdir": {
 			"version": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
@@ -3491,7 +5304,11 @@
 		"osenv": {
 			"version": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
 			"integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"os-homedir": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+				"os-tmpdir": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+			}
 		},
 		"p-map": {
 			"version": "1.1.1",
@@ -3507,22 +5324,58 @@
 		"param-case": {
 			"version": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
 			"integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"no-case": "https://registry.npmjs.org/no-case/-/no-case-2.3.1.tgz"
+			}
 		},
 		"parse-asn1": {
 			"version": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
 			"integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"asn1.js": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+				"browserify-aes": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+				"create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+				"evp_bytestokey": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.0.tgz",
+				"pbkdf2": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz"
+			}
+		},
+		"parse-css-font": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/parse-css-font/-/parse-css-font-2.0.2.tgz",
+			"integrity": "sha1-e2CwYHBaJam5C38O1JPlgjJIplI=",
+			"dev": true,
+			"requires": {
+				"css-font-size-keywords": "1.0.0",
+				"css-font-stretch-keywords": "1.0.1",
+				"css-font-style-keywords": "1.0.1",
+				"css-font-weight-keywords": "1.0.0",
+				"css-global-keywords": "1.0.1",
+				"css-list-helpers": "1.0.1",
+				"css-system-font-keywords": "1.0.0",
+				"tcomb": "2.7.0",
+				"unquote": "1.1.0"
+			}
 		},
 		"parse-glob": {
 			"version": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"glob-base": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+				"is-dotfile": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.2.tgz",
+				"is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+				"is-glob": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+			}
 		},
 		"parse-json": {
 			"version": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"error-ex": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+			}
 		},
 		"parse-uri": {
 			"version": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.0.tgz",
@@ -3541,7 +5394,11 @@
 		"path": {
 			"version": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
 			"integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"process": "https://registry.npmjs.org/process/-/process-0.11.9.tgz",
+				"util": "https://registry.npmjs.org/util/-/util-0.10.3.tgz"
+			}
 		},
 		"path-browserify": {
 			"version": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
@@ -3551,7 +5408,10 @@
 		"path-exists": {
 			"version": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+			}
 		},
 		"path-is-absolute": {
 			"version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -3571,12 +5431,20 @@
 		"path-type": {
 			"version": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+				"pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+				"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+			}
 		},
 		"pbkdf2": {
 			"version": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.9.tgz",
 			"integrity": "sha1-8sSyWmAAWLPDdzwIbDfbvuH/5pM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"create-hmac": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.4.tgz"
+			}
 		},
 		"performance-now": {
 			"version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
@@ -3596,7 +5464,10 @@
 		"pinkie-promise": {
 			"version": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"pinkie": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+			}
 		},
 		"pixi-gl-core": {
 			"version": "https://registry.npmjs.org/pixi-gl-core/-/pixi-gl-core-1.1.0.tgz",
@@ -3605,17 +5476,33 @@
 		"pixi-sound": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/pixi-sound/-/pixi-sound-1.4.2.tgz",
-			"integrity": "sha1-zvWzLjPQ3GoxtUOZ3Ch9tjLpLJg="
+			"integrity": "sha1-zvWzLjPQ3GoxtUOZ3Ch9tjLpLJg=",
+			"requires": {
+				"uuid": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+			}
 		},
 		"pixi.js": {
 			"version": "4.5.3",
 			"resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-4.5.3.tgz",
-			"integrity": "sha1-FpSOVbMfuefNc8fHAmcEcXE9Qzg="
+			"integrity": "sha1-FpSOVbMfuefNc8fHAmcEcXE9Qzg=",
+			"requires": {
+				"bit-twiddle": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+				"earcut": "https://registry.npmjs.org/earcut/-/earcut-2.1.1.tgz",
+				"eventemitter3": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-2.0.2.tgz",
+				"ismobilejs": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-0.4.1.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"pixi-gl-core": "https://registry.npmjs.org/pixi-gl-core/-/pixi-gl-core-1.1.0.tgz",
+				"remove-array-items": "1.0.0",
+				"resource-loader": "https://registry.npmjs.org/resource-loader/-/resource-loader-2.0.7.tgz"
+			}
 		},
 		"pkg-dir": {
 			"version": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
 			"integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+			}
 		},
 		"pkginfo": {
 			"version": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz",
@@ -3626,6 +5513,11 @@
 			"version": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
 			"integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
 			"dev": true,
+			"requires": {
+				"async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+				"debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+				"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+			},
 			"dependencies": {
 				"async": {
 					"version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -3638,100 +5530,183 @@
 			"version": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
 			"integrity": "sha1-cysxAAAPn/g3mkilODntCXN2rVc=",
 			"dev": true,
+			"requires": {
+				"chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+				"js-base64": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz",
+				"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+				"supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+			},
 			"dependencies": {
 				"supports-color": {
 					"version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+					}
 				}
 			}
 		},
 		"postcss-calc": {
 			"version": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
 			"integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-message-helpers": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
+				"reduce-css-calc": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz"
+			}
 		},
 		"postcss-colormin": {
 			"version": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
 			"integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"colormin": "https://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+			}
 		},
 		"postcss-convert-values": {
 			"version": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz",
 			"integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+			}
 		},
 		"postcss-discard-comments": {
 			"version": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz",
 			"integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+			}
 		},
 		"postcss-discard-duplicates": {
 			"version": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz",
 			"integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+			}
 		},
 		"postcss-discard-empty": {
 			"version": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz",
 			"integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+			}
 		},
 		"postcss-discard-overridden": {
 			"version": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz",
 			"integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+			}
 		},
 		"postcss-discard-unused": {
 			"version": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
 			"integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+			}
 		},
 		"postcss-filter-plugins": {
 			"version": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
 			"integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"uniqid": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz"
+			}
 		},
 		"postcss-load-config": {
 			"version": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
 			"integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.1.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"postcss-load-options": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
+				"postcss-load-plugins": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz"
+			}
 		},
 		"postcss-load-options": {
 			"version": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
 			"integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.1.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+			}
 		},
 		"postcss-load-plugins": {
 			"version": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
 			"integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"cosmiconfig": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.1.1.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+			}
 		},
 		"postcss-loader": {
 			"version": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-1.3.3.tgz",
 			"integrity": "sha1-piHqH6KQYqg5cqRvVEhncTAZFus=",
 			"dev": true,
+			"requires": {
+				"loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-load-config": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz"
+			},
 			"dependencies": {
 				"loader-utils": {
 					"version": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+						"emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+						"json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+					}
 				}
 			}
 		},
 		"postcss-merge-idents": {
 			"version": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz",
 			"integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+			}
 		},
 		"postcss-merge-longhand": {
 			"version": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz",
 			"integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+			}
 		},
 		"postcss-merge-rules": {
 			"version": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
 			"integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"browserslist": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.6.tgz",
+				"caniuse-api": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-1.5.3.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-selector-parser": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+				"vendors": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz"
+			}
 		},
 		"postcss-message-helpers": {
 			"version": "https://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz",
@@ -3741,42 +5716,80 @@
 		"postcss-minify-font-values": {
 			"version": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz",
 			"integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+			}
 		},
 		"postcss-minify-gradients": {
 			"version": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz",
 			"integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+			}
 		},
 		"postcss-minify-params": {
 			"version": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
 			"integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+				"uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+			}
 		},
 		"postcss-minify-selectors": {
 			"version": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
 			"integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+				"has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-selector-parser": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz"
+			}
 		},
 		"postcss-modules-extract-imports": {
 			"version": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.0.1.tgz",
 			"integrity": "sha1-j7P++abdBCDT9tQ1PPH/c/Kyo0E=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+			}
 		},
 		"postcss-modules-local-by-default": {
 			"version": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.1.1.tgz",
 			"integrity": "sha1-KaEGc/o30ZJRJlyiujFQ2QQOtM4=",
 			"dev": true,
+			"requires": {
+				"css-selector-tokenizer": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+			},
 			"dependencies": {
 				"css-selector-tokenizer": {
 					"version": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
 					"integrity": "sha1-ZEX1gseTDSQdzFAHpD1vy48HMVI=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"cssesc": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+						"fastparse": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+						"regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz"
+					}
 				},
 				"regexpu-core": {
 					"version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
 					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+						"regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+						"regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+					}
 				}
 			}
 		},
@@ -3784,68 +5797,127 @@
 			"version": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.0.2.tgz",
 			"integrity": "sha1-/5dzleXgYgLXNiKQuIsejNBJ3ik=",
 			"dev": true,
+			"requires": {
+				"css-selector-tokenizer": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+			},
 			"dependencies": {
 				"css-selector-tokenizer": {
 					"version": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
 					"integrity": "sha1-ZEX1gseTDSQdzFAHpD1vy48HMVI=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"cssesc": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+						"fastparse": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+						"regexpu-core": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz"
+					}
 				},
 				"regexpu-core": {
 					"version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
 					"integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+						"regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+						"regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+					}
 				}
 			}
 		},
 		"postcss-modules-values": {
 			"version": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.2.2.tgz",
 			"integrity": "sha1-8OfUdv4e2IxeTH+XUzo+dyrZTKE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"icss-replace-symbols": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.0.2.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+			}
 		},
 		"postcss-normalize-charset": {
 			"version": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz",
 			"integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+			}
 		},
 		"postcss-normalize-url": {
 			"version": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
 			"integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-absolute-url": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz",
+				"normalize-url": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+			}
 		},
 		"postcss-ordered-values": {
 			"version": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz",
 			"integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+			}
 		},
 		"postcss-reduce-idents": {
 			"version": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz",
 			"integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+			}
 		},
 		"postcss-reduce-initial": {
 			"version": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz",
 			"integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz"
+			}
 		},
 		"postcss-reduce-transforms": {
 			"version": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz",
 			"integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+			}
 		},
 		"postcss-selector-parser": {
 			"version": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
 			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"flatten": "https://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz",
+				"indexes-of": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+				"uniq": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+			}
 		},
 		"postcss-svgo": {
 			"version": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
 			"integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-svg": "https://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"postcss-value-parser": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
+				"svgo": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz"
+			}
 		},
 		"postcss-unique-selectors": {
 			"version": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
 			"integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"alphanum-sort": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+			}
 		},
 		"postcss-value-parser": {
 			"version": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
@@ -3855,7 +5927,12 @@
 		"postcss-zindex": {
 			"version": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
 			"integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"has": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+				"postcss": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
+				"uniqs": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+			}
 		},
 		"prelude-ls": {
 			"version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -3875,7 +5952,11 @@
 		"pretty-error": {
 			"version": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.0.3.tgz",
 			"integrity": "sha1-vtPYFqAI522mF83oIW9Ld4hJtdk=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"renderkid": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
+				"utila": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz"
+			}
 		},
 		"private": {
 			"version": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
@@ -3900,18 +5981,34 @@
 		"prompt": {
 			"version": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
 			"integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"pkginfo": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.0.tgz",
+				"read": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
+				"revalidator": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+				"utile": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+				"winston": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz"
+			}
 		},
 		"proxy-addr": {
 			"version": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.3.tgz",
 			"integrity": "sha1-3JdQL1ci6IhGez+iKXp7H/R98HQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"forwarded": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
+				"ipaddr.js": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.2.0.tgz"
+			}
 		},
 		"proxyquire": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-1.8.0.tgz",
 			"integrity": "sha1-AtUUpb7ZhvBMuyCTrxZ0FTX3ntw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"fill-keys": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
+				"module-not-found-error": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
+				"resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz"
+			}
 		},
 		"prr": {
 			"version": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
@@ -3926,7 +6023,14 @@
 		"public-encrypt": {
 			"version": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
 			"integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"bn.js": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
+				"browserify-rsa": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+				"create-hash": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.2.tgz",
+				"parse-asn1": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+				"randombytes": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz"
+			}
 		},
 		"punycode": {
 			"version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -3946,7 +6050,11 @@
 		"query-string": {
 			"version": "https://registry.npmjs.org/query-string/-/query-string-4.3.2.tgz",
 			"integrity": "sha1-7A/XZfWKUAMaOWjCQxOG+JR6XN0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+				"strict-uri-encode": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
+			}
 		},
 		"querystring": {
 			"version": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -3965,12 +6073,19 @@
 		},
 		"random-seed": {
 			"version": "https://registry.npmjs.org/random-seed/-/random-seed-0.3.0.tgz",
-			"integrity": "sha1-2UXy4fOPSejViRNDG4v2u5N1Vs0="
+			"integrity": "sha1-2UXy4fOPSejViRNDG4v2u5N1Vs0=",
+			"requires": {
+				"json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+			}
 		},
 		"randomatic": {
 			"version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.6.tgz",
 			"integrity": "sha1-EQ3Kv/OX6dz/fAeJzMCkmt8exbs=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-number": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+				"kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz"
+			}
 		},
 		"randombytes": {
 			"version": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.3.tgz",
@@ -3987,30 +6102,80 @@
 			"integrity": "sha1-DD0L6u2KAclm2Xh793goElKpeao=",
 			"dev": true
 		},
+		"rc": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+			"integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
+			"dev": true,
+			"requires": {
+				"deep-extend": "0.4.2",
+				"ini": "1.3.4",
+				"minimist": "1.2.0",
+				"strip-json-comments": "2.0.1"
+			},
+			"dependencies": {
+				"minimist": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+					"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+					"dev": true
+				},
+				"strip-json-comments": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+					"dev": true
+				}
+			}
+		},
 		"read": {
 			"version": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
 			"integrity": "sha1-AHo9FpR4qnEKSRcn5FPv+5LnYgM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"mute-stream": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz"
+			}
 		},
 		"read-pkg": {
 			"version": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"load-json-file": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+				"normalize-package-data": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.6.tgz",
+				"path-type": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+			}
 		},
 		"read-pkg-up": {
 			"version": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"find-up": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+				"read-pkg": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+			}
 		},
 		"readable-stream": {
 			"version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
 			"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+				"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+			}
 		},
 		"readdirp": {
 			"version": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 			"dev": true,
+			"requires": {
+				"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+				"minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+				"readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+				"set-immediate-shim": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+			},
 			"dependencies": {
 				"isarray": {
 					"version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4020,24 +6185,45 @@
 				"readable-stream": {
 					"version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
 					"integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+						"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+						"process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+						"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+						"util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+					}
 				}
 			}
 		},
 		"redent": {
 			"version": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"indent-string": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+				"strip-indent": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+			}
 		},
 		"reduce-css-calc": {
 			"version": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
 			"integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+				"math-expression-evaluator": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.16.tgz",
+				"reduce-function-call": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz"
+			}
 		},
 		"reduce-function-call": {
 			"version": "https://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
 			"integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+			}
 		},
 		"regenerate": {
 			"version": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
@@ -4052,17 +6238,31 @@
 		"regenerator-transform": {
 			"version": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz",
 			"integrity": "sha1-D4i7K8A5Mt23trcxLmgHjwECbWw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+				"babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.23.0.tgz",
+				"private": "https://registry.npmjs.org/private/-/private-0.1.7.tgz"
+			}
 		},
 		"regex-cache": {
 			"version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
 			"integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+				"is-primitive": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+			}
 		},
 		"regexpu-core": {
 			"version": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"regenerate": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+				"regjsgen": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+				"regjsparser": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz"
+			}
 		},
 		"regjsgen": {
 			"version": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
@@ -4073,6 +6273,9 @@
 			"version": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"dev": true,
+			"requires": {
+				"jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+			},
 			"dependencies": {
 				"jsesc": {
 					"version": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
@@ -4095,6 +6298,13 @@
 			"version": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.1.tgz",
 			"integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
 			"dev": true,
+			"requires": {
+				"css-select": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+				"dom-converter": "https://registry.npmjs.org/dom-converter/-/dom-converter-0.1.4.tgz",
+				"htmlparser2": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
+				"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+				"utila": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz"
+			},
 			"dependencies": {
 				"utila": {
 					"version": "https://registry.npmjs.org/utila/-/utila-0.3.3.tgz",
@@ -4116,12 +6326,39 @@
 		"repeating": {
 			"version": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-finite": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+			}
 		},
 		"request": {
 			"version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
 			"integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+				"aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+				"caseless": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+				"combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+				"extend": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+				"forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+				"form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+				"har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+				"hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+				"http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+				"is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+				"isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+				"json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+				"mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+				"oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+				"performance-now": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+				"qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+				"safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+				"stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+				"tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+				"tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+				"uuid": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+			}
 		},
 		"require-directory": {
 			"version": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -4150,7 +6387,11 @@
 		},
 		"resource-loader": {
 			"version": "https://registry.npmjs.org/resource-loader/-/resource-loader-2.0.7.tgz",
-			"integrity": "sha1-JGMkxT9490fP5XXtO9wRz/eaL/c="
+			"integrity": "sha1-JGMkxT9490fP5XXtO9wRz/eaL/c=",
+			"requires": {
+				"mini-signals": "https://registry.npmjs.org/mini-signals/-/mini-signals-1.1.1.tgz",
+				"parse-uri": "https://registry.npmjs.org/parse-uri/-/parse-uri-1.0.0.tgz"
+			}
 		},
 		"revalidator": {
 			"version": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
@@ -4160,12 +6401,18 @@
 		"right-align": {
 			"version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+			}
 		},
 		"rimraf": {
 			"version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
 			"integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz"
+			}
 		},
 		"ripemd160": {
 			"version": "https://registry.npmjs.org/ripemd160/-/ripemd160-1.0.1.tgz",
@@ -4186,11 +6433,21 @@
 			"version": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.1.2.tgz",
 			"integrity": "sha1-llEEviPoEDy35fcQ32WTWzF9pXs=",
 			"dev": true,
+			"requires": {
+				"glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+				"lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+				"yargs": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz"
+			},
 			"dependencies": {
 				"cliui": {
 					"version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+						"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+						"wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+					}
 				},
 				"window-size": {
 					"version": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
@@ -4200,7 +6457,23 @@
 				"yargs": {
 					"version": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
 					"integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"cliui": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+						"decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+						"get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+						"lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+						"os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+						"read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+						"require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+						"require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+						"set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+						"string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+						"which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+						"window-size": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+						"y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+						"yargs-parser": "https://registry.npmjs.com/yargs-parser/-/yargs-parser-2.4.1.tgz"
+					}
 				}
 			}
 		},
@@ -4209,30 +6482,54 @@
 			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-6.0.6.tgz",
 			"integrity": "sha512-c3/Zc+iW+qqDip6kXPYLEgsAu2lf4xz0EZDplB7EmSUMda12U1sGJPetH55B/j9eu0bTtKzKlNPWWyYC7wFNyQ==",
 			"dev": true,
+			"requires": {
+				"async": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+				"clone-deep": "0.3.0",
+				"loader-utils": "1.1.0",
+				"lodash.tail": "https://registry.npmjs.org/lodash.tail/-/lodash.tail-4.1.1.tgz",
+				"pify": "3.0.0"
+			},
 			"dependencies": {
 				"clone-deep": {
 					"version": "0.3.0",
 					"resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.3.0.tgz",
 					"integrity": "sha1-NIxhrpzb4O3+BT2R/0zFIdeQ7eg=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"for-own": "1.0.0",
+						"is-plain-object": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.1.tgz",
+						"kind-of": "3.2.2",
+						"shallow-clone": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz"
+					}
 				},
 				"for-own": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
 					"integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"for-in": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+					}
 				},
 				"kind-of": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+					}
 				},
 				"loader-utils": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+						"emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+						"json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+					}
 				},
 				"pify": {
 					"version": "3.0.0",
@@ -4252,12 +6549,21 @@
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.3.0.tgz",
 			"integrity": "sha1-9YdyIs4+kx7a4DnxfrNxbnE3+M8=",
 			"dev": true,
+			"requires": {
+				"ajv": "5.2.0"
+			},
 			"dependencies": {
 				"ajv": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.0.tgz",
 					"integrity": "sha1-wXNQJMXaLvdcwZBxMHPUTwmL9IY=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+						"fast-deep-equal": "0.1.0",
+						"json-schema-traverse": "0.3.1",
+						"json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+					}
 				}
 			}
 		},
@@ -4270,7 +6576,10 @@
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.9.1.tgz",
 			"integrity": "sha1-zdpEktcNSGVw+HxlVGAjVY4d+lo=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"node-forge": "0.6.33"
+			}
 		},
 		"semver": {
 			"version": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -4281,11 +6590,29 @@
 			"version": "https://registry.npmjs.org/send/-/send-0.15.1.tgz",
 			"integrity": "sha1-igI1TCbm9cynAAZfXwzeupDse18=",
 			"dev": true,
+			"requires": {
+				"debug": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
+				"depd": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+				"destroy": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+				"encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+				"escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+				"etag": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+				"fresh": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+				"http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+				"mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+				"ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+				"on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+				"range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+				"statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+			},
 			"dependencies": {
 				"debug": {
 					"version": "https://registry.npmjs.org/debug/-/debug-2.6.1.tgz",
 					"integrity": "sha1-eYVQkLosTjEVzH2HaUkdWPBJE1E=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"ms": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+					}
 				},
 				"mime": {
 					"version": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
@@ -4298,16 +6625,33 @@
 			"version": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
 			"integrity": "sha1-fF2WwT+xMRAfk8HFd0+FFqHnjTs=",
 			"dev": true,
+			"requires": {
+				"accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+				"batch": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz",
+				"debug": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+				"escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+				"http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
+				"mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+				"parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+			},
 			"dependencies": {
 				"debug": {
 					"version": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
 					"integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"ms": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+					}
 				},
 				"http-errors": {
 					"version": "https://registry.npmjs.org/http-errors/-/http-errors-1.5.1.tgz",
 					"integrity": "sha1-eIwNLB3iyBuebowBhDtrl+uSB1A=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.2.tgz",
+						"statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+					}
 				},
 				"ms": {
 					"version": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
@@ -4324,7 +6668,13 @@
 		"serve-static": {
 			"version": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.1.tgz",
 			"integrity": "sha1-dEOpZePO1kes61Y5+ga/TRu+ADk=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+				"escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+				"parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+				"send": "https://registry.npmjs.org/send/-/send-0.15.1.tgz"
+			}
 		},
 		"set-blocking": {
 			"version": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -4349,17 +6699,29 @@
 		"sha.js": {
 			"version": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
 			"integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+			}
 		},
 		"shallow-clone": {
 			"version": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
 			"integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
 			"dev": true,
+			"requires": {
+				"is-extendable": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+				"kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+				"lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
+				"mixin-object": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz"
+			},
 			"dependencies": {
 				"kind-of": {
 					"version": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
 					"integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+					}
 				},
 				"lazy-cache": {
 					"version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
@@ -4376,17 +6738,31 @@
 		"should": {
 			"version": "https://registry.npmjs.org/should/-/should-11.2.1.tgz",
 			"integrity": "sha1-kPVRRVUtAc/CAGZuToGKHJZw7aI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"should-equal": "https://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
+				"should-format": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
+				"should-type": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+				"should-type-adaptors": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.0.1.tgz",
+				"should-util": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz"
+			}
 		},
 		"should-equal": {
 			"version": "https://registry.npmjs.org/should-equal/-/should-equal-1.0.1.tgz",
 			"integrity": "sha1-C26VFvJgGp+wuy3MNpr6HH4gCvc=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"should-type": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz"
+			}
 		},
 		"should-format": {
 			"version": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
 			"integrity": "sha1-m/yPdPo5IFxT04w01xcwPidxJPE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"should-type": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+				"should-type-adaptors": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.0.1.tgz"
+			}
 		},
 		"should-type": {
 			"version": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
@@ -4396,7 +6772,11 @@
 		"should-type-adaptors": {
 			"version": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.0.1.tgz",
 			"integrity": "sha1-7+VVPN9oz/ZuXF9RtxLcNRx3vqo=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"should-type": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
+				"should-util": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz"
+			}
 		},
 		"should-util": {
 			"version": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
@@ -4413,6 +6793,16 @@
 			"resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.6.tgz",
 			"integrity": "sha1-lTeOfg+XapcS6bRZH/WznnPcPd4=",
 			"dev": true,
+			"requires": {
+				"diff": "3.2.0",
+				"formatio": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+				"lolex": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+				"native-promise-only": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+				"path-to-regexp": "1.7.0",
+				"samsam": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+				"text-encoding": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+				"type-detect": "4.0.3"
+			},
 			"dependencies": {
 				"diff": {
 					"version": "3.2.0",
@@ -4424,7 +6814,10 @@
 					"version": "1.7.0",
 					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
 					"integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+					}
 				},
 				"type-detect": {
 					"version": "4.0.3",
@@ -4442,12 +6835,19 @@
 		"sntp": {
 			"version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
 			"integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+			}
 		},
 		"sockjs": {
 			"version": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
 			"integrity": "sha1-2bKJMWyn33dZXvKZ4HXw+TfrQgc=",
 			"dev": true,
+			"requires": {
+				"faye-websocket": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+				"uuid": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
+			},
 			"dependencies": {
 				"uuid": {
 					"version": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
@@ -4460,18 +6860,32 @@
 			"version": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.2.tgz",
 			"integrity": "sha1-8CEqhVDkyUaMjM6u79LjSTwDOtU=",
 			"dev": true,
+			"requires": {
+				"debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+				"eventsource": "https://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+				"faye-websocket": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+				"url-parse": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.8.tgz"
+			},
 			"dependencies": {
 				"faye-websocket": {
 					"version": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
 					"integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"websocket-driver": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
+					}
 				}
 			}
 		},
 		"sort-keys": {
 			"version": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
 			"integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-plain-obj": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+			}
 		},
 		"source-list-map": {
 			"version": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz",
@@ -4486,12 +6900,18 @@
 		"source-map-support": {
 			"version": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.14.tgz",
 			"integrity": "sha1-nURjdyWYuGJxtPUj9sH04Cp9au8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+			}
 		},
 		"spdx-correct": {
 			"version": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"spdx-license-ids": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+			}
 		},
 		"spdx-expression-parse": {
 			"version": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
@@ -4506,12 +6926,26 @@
 		"spdy": {
 			"version": "https://registry.npmjs.org/spdy/-/spdy-3.4.4.tgz",
 			"integrity": "sha1-4EBkB8qQ/wG1U+sBNQVEJkn1qBk=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+				"handle-thing": "https://registry.npmjs.org/handle-thing/-/handle-thing-1.2.5.tgz",
+				"http-deceiver": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+				"select-hose": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+				"spdy-transport": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.18.tgz"
+			}
 		},
 		"spdy-transport": {
 			"version": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.18.tgz",
 			"integrity": "sha1-Q/ycVr4szMErs+J1SqlxFU6DbqY=",
 			"dev": true,
+			"requires": {
+				"debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+				"hpack.js": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+				"obuf": "https://registry.npmjs.org/obuf/-/obuf-1.1.1.tgz",
+				"readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+				"wbuf": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz"
+			},
 			"dependencies": {
 				"isarray": {
 					"version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4521,14 +6955,26 @@
 				"readable-stream": {
 					"version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
 					"integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+						"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+						"process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+						"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+						"util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+					}
 				}
 			}
 		},
 		"split": {
 			"version": "https://registry.npmjs.org/split/-/split-0.3.1.tgz",
 			"integrity": "sha1-zrzxQr9hu7ZLFBYo5ttIKikUZUw=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+			}
 		},
 		"sprintf-js": {
 			"version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4539,6 +6985,17 @@
 			"version": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
 			"integrity": "sha1-LY1eu0pvqyj/ujf6YqkPSj6lnXc=",
 			"dev": true,
+			"requires": {
+				"asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+				"assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+				"bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+				"dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+				"ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+				"getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+				"jodid25519": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+				"jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+				"tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+			},
 			"dependencies": {
 				"assert-plus": {
 					"version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -4561,6 +7018,9 @@
 			"version": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.0.tgz",
 			"integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
 			"dev": true,
+			"requires": {
+				"readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz"
+			},
 			"dependencies": {
 				"isarray": {
 					"version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4570,7 +7030,16 @@
 				"readable-stream": {
 					"version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
 					"integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+						"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+						"process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+						"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+						"util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+					}
 				}
 			}
 		},
@@ -4578,6 +7047,10 @@
 			"version": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
 			"integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
 			"dev": true,
+			"requires": {
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz"
+			},
 			"dependencies": {
 				"isarray": {
 					"version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4587,7 +7060,16 @@
 				"readable-stream": {
 					"version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
 					"integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+						"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+						"process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+						"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+						"util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+					}
 				}
 			}
 		},
@@ -4595,6 +7077,13 @@
 			"version": "https://registry.npmjs.org/stream-http/-/stream-http-2.6.3.tgz",
 			"integrity": "sha1-TD3b+WNZaOos/U5I1D3l3vJiWsM=",
 			"dev": true,
+			"requires": {
+				"builtin-status-codes": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+				"readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
+				"to-arraybuffer": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+				"xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+			},
 			"dependencies": {
 				"isarray": {
 					"version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -4604,7 +7093,16 @@
 				"readable-stream": {
 					"version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
 					"integrity": "sha1-i0Ou125xSDk40SqNRsbPGgCx+BY=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"buffer-shims": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+						"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+						"process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+						"string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+						"util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+					}
 				}
 			}
 		},
@@ -4621,7 +7119,12 @@
 		"string-width": {
 			"version": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"code-point-at": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+				"is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+				"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+			}
 		},
 		"stringstream": {
 			"version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
@@ -4631,17 +7134,26 @@
 		"strip-ansi": {
 			"version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+			}
 		},
 		"strip-bom": {
 			"version": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"is-utf8": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+			}
 		},
 		"strip-indent": {
 			"version": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"get-stdin": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+			}
 		},
 		"strip-json-comments": {
 			"version": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
@@ -4652,11 +7164,19 @@
 			"version": "https://registry.npmjs.org/style-loader/-/style-loader-0.14.1.tgz",
 			"integrity": "sha1-J7m2yYIq34xHSOAqHvriKUBdeaU=",
 			"dev": true,
+			"requires": {
+				"loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz"
+			},
 			"dependencies": {
 				"loader-utils": {
 					"version": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+						"emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+						"json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+					}
 				}
 			}
 		},
@@ -4669,6 +7189,23 @@
 			"version": "https://registry.npmjs.org/surge/-/surge-0.18.0.tgz",
 			"integrity": "sha1-HEN4x6UgS5b0Xurym/oRehmZXOk=",
 			"dev": true,
+			"requires": {
+				"du": "https://registry.npmjs.org/du/-/du-0.1.0.tgz",
+				"fstream-ignore": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
+				"is-domain": "https://registry.npmjs.org/is-domain/-/is-domain-0.0.1.tgz",
+				"minimist": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+				"moniker": "https://registry.npmjs.org/moniker/-/moniker-0.1.2.tgz",
+				"netrc": "https://registry.npmjs.org/netrc/-/netrc-0.1.4.tgz",
+				"progress": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+				"prompt": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
+				"read": "https://registry.npmjs.org/read/-/read-1.0.5.tgz",
+				"request": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+				"split": "https://registry.npmjs.org/split/-/split-0.3.1.tgz",
+				"surge-ignore": "https://registry.npmjs.org/surge-ignore/-/surge-ignore-0.2.0.tgz",
+				"tar": "https://registry.npmjs.org/tar/-/tar-1.0.0.tgz",
+				"tar.gz": "https://registry.npmjs.org/tar.gz/-/tar.gz-0.1.1.tgz",
+				"url-parse-as-address": "https://registry.npmjs.org/url-parse-as-address/-/url-parse-as-address-1.0.0.tgz"
+			},
 			"dependencies": {
 				"asn1": {
 					"version": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
@@ -4697,19 +7234,28 @@
 				"boom": {
 					"version": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
 					"integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"hoek": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+					}
 				},
 				"combined-stream": {
 					"version": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
 					"integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+					}
 				},
 				"cryptiles": {
 					"version": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
 					"integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"boom": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+					}
 				},
 				"delayed-stream": {
 					"version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
@@ -4726,13 +7272,24 @@
 					"version": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
 					"integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"async": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+						"combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+						"mime": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+					}
 				},
 				"hawk": {
 					"version": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
 					"integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"boom": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+						"cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+						"hoek": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+						"sntp": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+					}
 				},
 				"hoek": {
 					"version": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
@@ -4743,7 +7300,12 @@
 					"version": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
 					"integrity": "sha1-T72sEyVZqoMjEh5UB3nAoBKyfmY=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"asn1": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+						"assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+						"ctype": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+					}
 				},
 				"mime-types": {
 					"version": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
@@ -4774,18 +7336,41 @@
 				"request": {
 					"version": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
 					"integrity": "sha1-TdZw9pbx5uhC5mtLXoOTAaub62c=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+						"forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+						"form-data": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+						"hawk": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+						"http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+						"json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+						"mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+						"node-uuid": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+						"oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+						"qs": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz",
+						"stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+						"tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+						"tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+					}
 				},
 				"sntp": {
 					"version": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
 					"integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
 					"dev": true,
-					"optional": true
+					"optional": true,
+					"requires": {
+						"hoek": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+					}
 				},
 				"tar": {
 					"version": "https://registry.npmjs.org/tar/-/tar-1.0.0.tgz",
 					"integrity": "sha1-NmNtduiuErS8EalArGBrXKil/h8=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+						"fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+					}
 				},
 				"tunnel-agent": {
 					"version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
@@ -4803,7 +7388,16 @@
 		"svgo": {
 			"version": "https://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
 			"integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"coa": "https://registry.npmjs.org/coa/-/coa-1.0.1.tgz",
+				"colors": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+				"csso": "https://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+				"js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+				"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+				"sax": "https://registry.npmjs.org/sax/-/sax-1.2.2.tgz",
+				"whet.extend": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
+			}
 		},
 		"symbol-tree": {
 			"version": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
@@ -4818,34 +7412,132 @@
 		"tar": {
 			"version": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+				"fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+			}
+		},
+		"tar-pack": {
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+			"integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
+			"dev": true,
+			"requires": {
+				"debug": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
+				"fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+				"fstream-ignore": "1.0.5",
+				"once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+				"readable-stream": "2.3.3",
+				"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+				"tar": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+				"uid-number": "0.0.6"
+			},
+			"dependencies": {
+				"fstream-ignore": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+					"integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
+					"dev": true,
+					"requires": {
+						"fstream": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz"
+					}
+				},
+				"isarray": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+					"dev": true
+				},
+				"readable-stream": {
+					"version": "2.3.3",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+					"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+					"dev": true,
+					"requires": {
+						"core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"isarray": "1.0.0",
+						"process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.0.3",
+						"util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+					}
+				},
+				"safe-buffer": {
+					"version": "5.1.1",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+					"dev": true
+				},
+				"string_decoder": {
+					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+					"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "5.1.1"
+					}
+				}
+			}
 		},
 		"tar.gz": {
 			"version": "https://registry.npmjs.org/tar.gz/-/tar.gz-0.1.1.tgz",
 			"integrity": "sha1-6RTOI7L9xidXX72zSFpbIo7VmUc=",
 			"dev": true,
+			"requires": {
+				"commander": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
+				"fstream": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+				"tar": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz"
+			},
 			"dependencies": {
 				"commander": {
 					"version": "https://registry.npmjs.org/commander/-/commander-1.1.1.tgz",
 					"integrity": "sha1-UNFlGGiuYOzP8KLZ80WVN2vGsEE=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"keypress": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz"
+					}
 				},
 				"fstream": {
 					"version": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
 					"integrity": "sha1-czfwWPu7vvqMn1YaKMqwhJICyYg=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+						"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+						"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+					}
 				},
 				"graceful-fs": {
 					"version": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
 					"integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"natives": "https://registry.npmjs.org/natives/-/natives-1.1.0.tgz"
+					}
 				},
 				"tar": {
 					"version": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
 					"integrity": "sha1-QpQLrltfIsdEg2mRJvnz8nRJyxM=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"block-stream": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+						"fstream": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+						"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+					}
 				}
 			}
+		},
+		"tcomb": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/tcomb/-/tcomb-2.7.0.tgz",
+			"integrity": "sha1-ENYpWAQWaaXVNWe5pO6M3iKxwrA=",
+			"dev": true
 		},
 		"text-encoding": {
 			"version": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
@@ -4866,7 +7558,10 @@
 		"timers-browserify": {
 			"version": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
 			"integrity": "sha1-q0iDz1l9zVCvIRNJoA+8pWrIa4Y=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"setimmediate": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+			}
 		},
 		"to-arraybuffer": {
 			"version": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -4886,7 +7581,10 @@
 		"tough-cookie": {
 			"version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
 			"integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+			}
 		},
 		"tr46": {
 			"version": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -4908,12 +7606,23 @@
 			"resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-2.2.2.tgz",
 			"integrity": "sha512-HiusedxruMeHN1/BzpijS/rXSdup2P/IopamX235tLS3OuPU+eSXNyN3YgbHKzYEe71YkUhnm7X+VY4oOAGLtg==",
 			"dev": true,
+			"requires": {
+				"colors": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+				"enhanced-resolve": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz",
+				"loader-utils": "1.1.0",
+				"semver": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+			},
 			"dependencies": {
 				"loader-utils": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+						"emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+						"json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+					}
 				}
 			}
 		},
@@ -4925,7 +7634,10 @@
 		"tunnel-agent": {
 			"version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+			}
 		},
 		"tweetnacl": {
 			"version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
@@ -4936,7 +7648,10 @@
 		"type-check": {
 			"version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+			}
 		},
 		"type-detect": {
 			"version": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
@@ -4946,7 +7661,11 @@
 		"type-is": {
 			"version": "https://registry.npmjs.org/type-is/-/type-is-1.6.14.tgz",
 			"integrity": "sha1-4hljnBfe0coHiQkt1UoDgmuBfLI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"media-typer": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+				"mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz"
+			}
 		},
 		"typescript": {
 			"version": "2.4.1",
@@ -4957,11 +7676,22 @@
 		"uglify-js": {
 			"version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.14.tgz",
 			"integrity": "sha1-JbFdGvObIXUu4zcDrb9DLovI930=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+				"uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+				"yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+			}
 		},
 		"uglify-to-browserify": {
 			"version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
 			"integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+			"dev": true
+		},
+		"uid-number": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+			"integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
 			"dev": true
 		},
 		"underscore": {
@@ -4976,16 +7706,35 @@
 		"uniqid": {
 			"version": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
 			"integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"macaddress": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz"
+			}
 		},
 		"uniqs": {
 			"version": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
 			"integrity": "sha1-/+3ks2slKQaW5uFl1KWe25mOawI=",
 			"dev": true
 		},
+		"units-css": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/units-css/-/units-css-0.4.0.tgz",
+			"integrity": "sha1-1iKGU6UZg9fBb/KPi53Dsf/tOgc=",
+			"dev": true,
+			"requires": {
+				"isnumeric": "0.2.0",
+				"viewport-dimensions": "0.2.0"
+			}
+		},
 		"unpipe": {
 			"version": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
 			"integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+			"dev": true
+		},
+		"unquote": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.0.tgz",
+			"integrity": "sha1-mOH8YItrhUx1r7G5WvwJm6adlC8=",
 			"dev": true
 		},
 		"upper-case": {
@@ -4997,6 +7746,10 @@
 			"version": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
 			"integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
 			"dev": true,
+			"requires": {
+				"punycode": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+				"querystring": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+			},
 			"dependencies": {
 				"punycode": {
 					"version": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -5010,12 +7763,21 @@
 			"resolved": "https://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
 			"integrity": "sha512-B7QYFyvv+fOBqBVeefsxv6koWWtjmHaMFT6KZWti4KRw8YUD/hOU+3AECvXuzyVawIBx3z7zQRejXCDSO5kk1Q==",
 			"dev": true,
+			"requires": {
+				"loader-utils": "1.1.0",
+				"mime": "1.3.6"
+			},
 			"dependencies": {
 				"loader-utils": {
 					"version": "1.1.0",
 					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
 					"integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"big.js": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+						"emojis-list": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+						"json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+					}
 				},
 				"mime": {
 					"version": "1.3.6",
@@ -5028,7 +7790,11 @@
 		"url-parse": {
 			"version": "https://registry.npmjs.org/url-parse/-/url-parse-1.1.8.tgz",
 			"integrity": "sha1-emWzqNV6Hoava04iduNHdBZ8AVY=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"querystringify": "https://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz",
+				"requires-port": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+			}
 		},
 		"url-parse-as-address": {
 			"version": "https://registry.npmjs.org/url-parse-as-address/-/url-parse-as-address-1.0.0.tgz",
@@ -5039,6 +7805,9 @@
 			"version": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
 			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
 			"dev": true,
+			"requires": {
+				"inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+			},
 			"dependencies": {
 				"inherits": {
 					"version": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
@@ -5061,6 +7830,14 @@
 			"version": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
 			"integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
 			"dev": true,
+			"requires": {
+				"async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+				"deep-equal": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+				"i": "https://registry.npmjs.org/i/-/i-0.3.5.tgz",
+				"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+				"ncp": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+				"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+			},
 			"dependencies": {
 				"async": {
 					"version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
@@ -5081,7 +7858,11 @@
 		"validate-npm-package-license": {
 			"version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"spdx-correct": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+				"spdx-expression-parse": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+			}
 		},
 		"vary": {
 			"version": "https://registry.npmjs.org/vary/-/vary-1.1.0.tgz",
@@ -5096,22 +7877,42 @@
 		"verror": {
 			"version": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
 			"integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+			"dev": true,
+			"requires": {
+				"extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+			}
+		},
+		"viewport-dimensions": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/viewport-dimensions/-/viewport-dimensions-0.2.0.tgz",
+			"integrity": "sha1-3nQHR9tTh/0XJfUXXpG6x2r982w=",
 			"dev": true
 		},
 		"vm-browserify": {
 			"version": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
 			"integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"indexof": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+			}
 		},
 		"watchpack": {
 			"version": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
 			"integrity": "sha1-fYaTkHsozmAT5/NhCqKhrPB9rYc=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"async": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+				"chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+				"graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+			}
 		},
 		"wbuf": {
 			"version": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.2.tgz",
 			"integrity": "sha1-1pe5nx9ZUS3ydRvkJ2nBWAtYAf4=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"minimalistic-assert": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz"
+			}
 		},
 		"webfontloader": {
 			"version": "1.6.28",
@@ -5128,6 +7929,29 @@
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-2.6.1.tgz",
 			"integrity": "sha1-LgRX8KuxrF3zqxBsacZy8jZ4Xwc=",
 			"dev": true,
+			"requires": {
+				"acorn": "5.0.3",
+				"acorn-dynamic-import": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+				"ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
+				"ajv-keywords": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+				"async": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+				"enhanced-resolve": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.1.0.tgz",
+				"interpret": "https://registry.npmjs.org/interpret/-/interpret-1.0.1.tgz",
+				"json-loader": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.4.tgz",
+				"json5": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+				"loader-runner": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+				"loader-utils": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+				"memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+				"mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+				"node-libs-browser": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
+				"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+				"supports-color": "3.2.3",
+				"tapable": "https://registry.npmjs.org/tapable/-/tapable-0.2.6.tgz",
+				"uglify-js": "2.8.29",
+				"watchpack": "https://registry.npmjs.org/watchpack/-/watchpack-1.3.1.tgz",
+				"webpack-sources": "0.2.3",
+				"yargs": "6.6.0"
+			},
 			"dependencies": {
 				"acorn": {
 					"version": "5.0.3",
@@ -5145,19 +7969,33 @@
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+					}
 				},
 				"uglify-js": {
 					"version": "2.8.29",
 					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
 					"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
 					"dev": true,
+					"requires": {
+						"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+						"uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+						"yargs": "3.10.0"
+					},
 					"dependencies": {
 						"yargs": {
 							"version": "3.10.0",
 							"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 							"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-							"dev": true
+							"dev": true,
+							"requires": {
+								"camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+								"cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+								"decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+								"window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+							}
 						}
 					}
 				},
@@ -5165,13 +8003,32 @@
 					"version": "0.2.3",
 					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
 					"integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"source-list-map": "1.1.2",
+						"source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+					}
 				},
 				"yargs": {
 					"version": "6.6.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
 					"dev": true,
+					"requires": {
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+						"get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+						"os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+						"read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+						"require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+						"require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+						"set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+						"string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+						"which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+						"y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+						"yargs-parser": "4.2.1"
+					},
 					"dependencies": {
 						"camelcase": {
 							"version": "3.0.0",
@@ -5183,7 +8040,12 @@
 							"version": "3.2.0",
 							"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 							"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-							"dev": true
+							"dev": true,
+							"requires": {
+								"string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+								"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+								"wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+							}
 						}
 					}
 				},
@@ -5192,6 +8054,9 @@
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
 					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
 					"dev": true,
+					"requires": {
+						"camelcase": "3.0.0"
+					},
 					"dependencies": {
 						"camelcase": {
 							"version": "3.0.0",
@@ -5208,6 +8073,29 @@
 			"resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-2.5.0.tgz",
 			"integrity": "sha1-TTanKLA7iyr6SO0wJCiEfOooQK0=",
 			"dev": true,
+			"requires": {
+				"ansi-html": "https://registry.npmjs.org/ansi-html/-/ansi-html-0.0.7.tgz",
+				"bonjour": "3.5.0",
+				"chokidar": "https://registry.npmjs.org/chokidar/-/chokidar-1.6.1.tgz",
+				"compression": "https://registry.npmjs.org/compression/-/compression-1.6.2.tgz",
+				"connect-history-api-fallback": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz",
+				"del": "3.0.0",
+				"express": "https://registry.npmjs.org/express/-/express-4.15.2.tgz",
+				"html-entities": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.0.tgz",
+				"http-proxy-middleware": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+				"internal-ip": "1.2.0",
+				"opn": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+				"portfinder": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.13.tgz",
+				"selfsigned": "1.9.1",
+				"serve-index": "https://registry.npmjs.org/serve-index/-/serve-index-1.8.0.tgz",
+				"sockjs": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
+				"sockjs-client": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.2.tgz",
+				"spdy": "https://registry.npmjs.org/spdy/-/spdy-3.4.4.tgz",
+				"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+				"supports-color": "3.2.3",
+				"webpack-dev-middleware": "1.11.0",
+				"yargs": "6.6.0"
+			},
 			"dependencies": {
 				"camelcase": {
 					"version": "3.0.0",
@@ -5219,19 +8107,39 @@
 					"version": "3.2.0",
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+						"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+						"wrap-ansi": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+					}
 				},
 				"del": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
 					"integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"globby": "6.1.0",
+						"is-path-cwd": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+						"is-path-in-cwd": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+						"p-map": "1.1.1",
+						"pify": "3.0.0",
+						"rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+					}
 				},
 				"globby": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
 					"integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
 					"dev": true,
+					"requires": {
+						"array-union": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+						"glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+						"object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+						"pify": "2.3.0",
+						"pinkie-promise": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+					},
 					"dependencies": {
 						"pify": {
 							"version": "2.3.0",
@@ -5257,32 +8165,62 @@
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+					}
 				},
 				"webpack-dev-middleware": {
 					"version": "1.11.0",
 					"resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.11.0.tgz",
 					"integrity": "sha1-CWkdCXOjCtH4Ksc6EuIIfwpHVPk=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"memory-fs": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+						"mime": "1.3.6",
+						"path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+						"range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+					}
 				},
 				"yargs": {
 					"version": "6.6.0",
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"camelcase": "3.0.0",
+						"cliui": "3.2.0",
+						"decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+						"get-caller-file": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+						"os-locale": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+						"read-pkg-up": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+						"require-directory": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+						"require-main-filename": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+						"set-blocking": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+						"string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+						"which-module": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+						"y18n": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+						"yargs-parser": "4.2.1"
+					}
 				},
 				"yargs-parser": {
 					"version": "4.2.1",
 					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
 					"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
-					"dev": true
+					"dev": true,
+					"requires": {
+						"camelcase": "3.0.0"
+					}
 				}
 			}
 		},
 		"websocket-driver": {
 			"version": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
 			"integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"websocket-extensions": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+			}
 		},
 		"websocket-extensions": {
 			"version": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
@@ -5292,12 +8230,19 @@
 		"whatwg-encoding": {
 			"version": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
 			"integrity": "sha1-PGxFGhmO567FWx7GHQkgxngBpfQ=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+			}
 		},
 		"whatwg-url": {
 			"version": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.7.0.tgz",
 			"integrity": "sha1-ICA1rBlVsIfN0g+otY3tOrHNKvU=",
 			"dev": true,
+			"requires": {
+				"tr46": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+				"webidl-conversions": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
+			},
 			"dependencies": {
 				"webidl-conversions": {
 					"version": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -5314,7 +8259,10 @@
 		"which": {
 			"version": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
 			"integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+			}
 		},
 		"which-module": {
 			"version": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
@@ -5324,7 +8272,10 @@
 		"wide-align": {
 			"version": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.0.tgz",
 			"integrity": "sha1-QO3egCpx/qHwcNo+YtzaLnrdlq0=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+			}
 		},
 		"window-size": {
 			"version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -5335,6 +8286,15 @@
 			"version": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
 			"integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
 			"dev": true,
+			"requires": {
+				"async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+				"colors": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+				"cycle": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+				"eyes": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+				"isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+				"pkginfo": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+				"stack-trace": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+			},
 			"dependencies": {
 				"async": {
 					"version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
@@ -5361,7 +8321,11 @@
 		"wrap-ansi": {
 			"version": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"string-width": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+				"strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+			}
 		},
 		"wrappy": {
 			"version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -5396,12 +8360,22 @@
 		"yargs": {
 			"version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
 			"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-			"dev": true
+			"dev": true,
+			"requires": {
+				"camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+				"cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+				"decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+				"window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+			}
 		},
 		"yargs-parser": {
 			"version": "https://registry.npmjs.com/yargs-parser/-/yargs-parser-2.4.1.tgz",
 			"integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
 			"dev": true,
+			"requires": {
+				"camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+				"lodash.assign": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+			},
 			"dependencies": {
 				"camelcase": {
 					"version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"babel-core": "^6.25.0",
 		"babel-loader": "^6.4.0",
 		"babel-preset-env": "^1.5.2",
+		"canvas-prebuilt": "^1.6.5-prerelease.1",
 		"chai": "^3.5.0",
 		"copy-webpack-plugin": "^4.0.1",
 		"css-loader": "^0.27.3",


### PR DESCRIPTION
This should solve all problems around the node-canvas class and it wrecking the unit tests on windows (only if running a 64-bit version).
Don't forget to do a npm install after merging this module to really install the canvas module.