### PR TITLE
Properly handle escaped brackets in string evaluation

### DIFF
--- a/src/js/osweb/classes/syntax.js
+++ b/src/js/osweb/classes/syntax.js
@@ -118,7 +118,7 @@ export default class Syntax {
 
         /** The replacer function detects variable entries in the passed text
         and replaces them with variable values as found in OpenSesame's var store */
-        let result = text.replace(/\[(\w+|=.+)\]/g, (match, content, offset, string) => {
+        let result = text.replace(/\[(\w+|=.+?)\]/g, (match, content, offset, string) => {
             // Check if the current match is escaped, and simply return it untouched if so.
             if (string[offset-1] === "\\" && string[offset-2] !== "\\") return match;
 

--- a/src/js/osweb/classes/syntax.js
+++ b/src/js/osweb/classes/syntax.js
@@ -116,14 +116,15 @@ export default class Syntax {
             return text;
         }
 
+        text = this.escapeBrackets(text);
         /** The replacer function detects variable entries in the passed text
         and replaces them with variable values as found in OpenSesame's var store */
         let result = text.replace(/\[(\w+|=.+?)\]/g, (match, content, offset, string) => {
-            // Check if the current match is escaped, and simply return it untouched if so.
-            if (string[offset-1] === "\\" && string[offset-2] !== "\\") return match;
-
+            // // Check if the current match is escaped, and simply return it untouched if so.
+            // if (string[offset-1] === "\\" && string[offset-2] !== "\\") return match;
             // Check if contents of [] start with an =. In this case they should be
             // evaluated as a Python statement
+            content = this.unescapeBrackets(content);
             if (content[0] === '=') {
                 // Convert python statement to ast tree and run it.
                 const ast = this._runner._pythonParser._parse(content.substring(1, content.length));
@@ -149,7 +150,7 @@ export default class Syntax {
         });
 
         // Check if contenst has additional quotes
-        return this.strip_slashes(result);
+        return this.strip_slashes(this.unescapeBrackets(result));
     }
 
     /**
@@ -290,5 +291,43 @@ export default class Syntax {
         var result = line.match(/(?:[^\s"]+|"[^"]*")+/g);
         return (result !== null) ? result : [];
     }
+    
+    /**
+     * Replaces all escaped brackets by a placeholder string of the format
+     * `%%OPEN:1:%%`
+     * @param {String} text - The text to escape.
+     * @return {String} - The escaped text.
+     */
+    escapeBrackets(text) {
+    
+        let result = text.replace(/\\+[\[\]]/g, (match, content, offset, str) => {
+            let n_brackets = match.length-1;
+            if (n_brackets % 2 == 1) {
+                let chartype = match[match.length-1] == '[' ? 'OPEN' : 'CLOSE';
+                return `%%${chartype}:${n_brackets}:%%`;
+            }
+            return match;
+        })
+        return result;
+    }
+    
+    /**
+     * Replaces all placeholder strings by escaped brackets.
+     * `%%OPEN:1:%%`
+     * @param {String} text - The text to unescape.
+     * @return {String} - The unescaped text.
+     */	
+    unescapeBrackets(text) {
+    
+        let result = text.replace(/%%(OPEN|CLOSE):\d+:%%/g, (match, content, offset, str) => {		
+            let chartype = match.substr(2,4) == 'OPEN' ? '[' : ']';
+            let i1 = match.indexOf(':')+1;
+            let i2 = match.lastIndexOf(':');
+            let n_brackets = parseInt(match.substr(i1, i2-i1));
+            return Array(n_brackets).join('\\') + chartype;
+        })
+        return result;	
+    }
+    
 }
  

--- a/test/test.js
+++ b/test/test.js
@@ -248,7 +248,15 @@ describe('Syntax', function() {
 		});
 		it('Should process string code: [="\\[test\\]"]', function() {
 			expect(runner._syntax.eval_text(
-				'[="\[test\]"]', tmp_var_store)).to.equal('[test]');
+				'[="\\[test\\]"]', tmp_var_store)).to.equal('[test]');
+		});
+		it('Should process multiple variables: w: [width], h: [height]', function() {
+			expect(runner._syntax.eval_text(
+				'w: [width], h: [height]', tmp_var_store)).to.equal('w: 1024, h: 768');
+		});
+		it('Should process multiple code blocks: w: [=1024], h: [=768]', function() {
+			expect(runner._syntax.eval_text(
+				'w: [=1024], h: [=768]', tmp_var_store)).to.equal('w: 1024, h: 768');
 		});
 	});
 


### PR DESCRIPTION
After struggling for a while with regular expressions, I decided to take the easy way out here. Right now, all escaped brackets are re-escaped with a special character sequence that indicates the number of slashes and whether it's an opening or closing bracket.

~~~
\\\[test]
~~~

Becomes

~~~
%%OPEN:3:%%test]
~~~

And then this is undone after the regular expression.

This passes the unittests for me, and also fixes some other issues.