### PR TITLE
canvas: give informative error message when image is not found in pool

### DIFF
--- a/src/js/osweb/backends/canvas.js
+++ b/src/js/osweb/backends/canvas.js
@@ -581,9 +581,12 @@ export default class Canvas {
     image(fname, center, x, y, scale) {
         // Get image from file pool.
         var name = this.experiment._runner._syntax.remove_quotes(fname);
-        var img = this.experiment._runner._pool[name].data;
-
-        // Create a temporary canvas to make an image data array.        
+        var path = this.experiment._runner._pool[name];
+        if (typeof(path) == 'undefined') {
+            this.experiment._runner._debugger.addError(`"${fname}" does not exist`);
+        }
+        var img = path.data;
+        // Create a temporary canvas to make an image data array.
         var canvas = document.createElement('canvas');
         canvas.width = img.width;
         canvas.height = img.height;


### PR DESCRIPTION
A simple fix to provide a more informative error message when trying to present an image that was not in the file pool. This happened to me and because of the opaque error message it took me a while to discover that this was actually the problem.

Question: Is this the proper way to deal with errors?