### PR TITLE
Add random, unique sessionid variable

### DIFF
--- a/src/js/osweb/items/experiment.js
+++ b/src/js/osweb/items/experiment.js
@@ -38,7 +38,7 @@ export default class Experiment extends Item {
     this.vars.round_decimals = 2
     this.vars.form_clicks = 'no'
     this.vars.uniform_coordinates = 'no'
-    this.vars.sessionid = new Date().valueOf() + Math.floor(Math.random() * 100000);
+    this.vars.sessionid = new Date().valueOf() + Math.floor(Math.random() * 100000)
 
     // Sound parameters.
     this.vars.sound_freq = 48000

--- a/src/js/osweb/items/experiment.js
+++ b/src/js/osweb/items/experiment.js
@@ -38,6 +38,7 @@ export default class Experiment extends Item {
     this.vars.round_decimals = 2
     this.vars.form_clicks = 'no'
     this.vars.uniform_coordinates = 'no'
+    this.vars.sessionid = new Date().valueOf() + Math.floor(Math.random() * 100000);
 
     // Sound parameters.
     this.vars.sound_freq = 48000


### PR DESCRIPTION
It's convenient to have a random-but-unique session id. This allows the experiment to pair sessions that belong to the same participant, even if a logging system is used in which all logged data is thrown onto a big pile.