### PR TITLE
Remove negative lookbehind to preserve compatibility with ECMA2016

### DIFF
--- a/src/js/osweb/classes/syntax.js
+++ b/src/js/osweb/classes/syntax.js
@@ -204,7 +204,10 @@ export default class Syntax {
    * @return {String} - The stripped string.
    */
   strip_slashes (line) {
-    return line.replace(/(?<!\\)\\(?=['"\\])/mg, '')
+    // Negative lookbehinds require ECMA2018, therefore we fall
+    // back to a more clunky technique
+    // return line.replace(/(?<!\\)\\(?=['"\\])/mg, '')
+    return line.replace(/\\(?=['"])/mg, '').replace(/\\\\/mg, '\\')
   }
 
   /**

--- a/src/js/osweb/index.js
+++ b/src/js/osweb/index.js
@@ -15,7 +15,7 @@
 import Runner from './system/runner.js'
 
 export const VERSION_NAME = 'OSWeb (ES2016)'
-export const VERSION_NUMBER = '3.0.055 (11-05-2017)'
+export const VERSION_NUMBER = '1.0.2'
 
 // Add replaceAll function to string prototype
 String.prototype.replaceAll = function (str1, str2, ignore) {

--- a/src/js/tests/classes/syntax.test.js
+++ b/src/js/tests/classes/syntax.test.js
@@ -28,6 +28,7 @@ describe('Syntax', function () {
       for (const [input, expectedOutput] of [
         ['\\\\', '\\'],
         ['\\\\\\', '\\\\'],
+        ['\\\\\\"\\\\\\"', '\\"\\"'],
         ['"\\"quoted\\""', '""quoted""']
       ]) {
         expect(runner._syntax.strip_slashes(input)).toBe(expectedOutput)


### PR DESCRIPTION
The negative lookbehind was introduced in ECMA2018, and doesn't work in Firefox and other browsers yet.