### PR TITLE
Support four touch-start events + capybara experiment

### DIFF
--- a/src/js/osweb/system/events.js
+++ b/src/js/osweb/system/events.js
@@ -76,9 +76,11 @@ export default class Events {
     this._mouseDownHandler = this._mouseDown.bind(this)
     this._mouseMoveHandler = this._mouseMove.bind(this)
     this._mouseUpHandler = this._mouseUp.bind(this)
+    this._touchStartHandler = this._touchStart.bind(this)
     this._runner._renderer.view.addEventListener('mousedown', this._mouseDownHandler)
     this._runner._renderer.view.addEventListener('mousemove', this._mouseMoveHandler)
     this._runner._renderer.view.addEventListener('mouseup', this._mouseUpHandler)
+    this._runner._renderer.view.addEventListener('touchstart', this._touchStartHandler)
 
     // Set the current item to the experiment object.
     this._currentItem = this._runner._experiment
@@ -100,6 +102,7 @@ export default class Events {
     this._runner._renderer.view.removeEventListener('mousedown', this._mouseDownHandler)
     this._runner._renderer.view.removeEventListener('mousemove', this._mouseMoveHandler)
     this._runner._renderer.view.removeEventListener('mouseup', this._mouseUpHandler)
+    this._runner._renderer.view.removeEventListener('touchstart', this._touchStartHandler)
 
     // Stop the timing event listener.
     this._timeHandler.stop()
@@ -228,11 +231,25 @@ export default class Events {
   }
 
   /**
+     * Event handler for touch start events, which for now are translated to
+     * moudown events.
+     * @param {Object} event - system touchstart event.
+     */
+  _touchStart (event) {
+    console.log(event)
+    event.button = 0
+    event.clientX = event.changedTouches[0].clientX
+    event.clientY = event.changedTouches[0].clientY
+    this._mouseDown(event)
+  }
+
+  /**
      * Event handler for retrieving mouse down events.
      * @param {Object} event - system mousedown event.
      */
   _mouseDown (event) {
     // Store the mouse down event and its timestamp for use in the mouse class.
+    console.log(event)
     this._mouseDownEvent = {
       'event': event,
       'rtTime': this._runner._experiment.clock.time()

--- a/src/js/osweb/widgets/button.js
+++ b/src/js/osweb/widgets/button.js
@@ -64,6 +64,7 @@ export default class ButtonWidget extends Widget {
       this._container.buttonMode = true
       this._container.hitArea = new PIXI.Rectangle(0, 0, this._container._width, this._container._height)
       this._container.on('mousedown', function (event) { this.response(event) }.bind(this))
+      this._container.on('touchstart', function (event) { this.response(event) }.bind(this))
     }
 
     // Draw the frame (if enabled).

--- a/src/js/osweb/widgets/checkbox.js
+++ b/src/js/osweb/widgets/checkbox.js
@@ -94,6 +94,9 @@ export default class CheckBoxWidget extends Widget {
       this._container.on('mousedown', function (event) {
         this.response(event)
       }.bind(this))
+      this._container.on('touchstart', function (event) {
+        this.response(event)
+      }.bind(this))
     }
 
     // Clear the old content.

--- a/src/js/osweb/widgets/image_button.js
+++ b/src/js/osweb/widgets/image_button.js
@@ -34,6 +34,9 @@ export default class ImageButtonWidget extends ImageWidget {
       this._container.on('mousedown', function (event) {
         this.response(event)
       }.bind(this))
+      this._container.on('touchstart', function (event) {
+        this.response(event)
+      }.bind(this))
     }
 
     // Inherited.

--- a/src/js/osweb/widgets/rating_scale.js
+++ b/src/js/osweb/widgets/rating_scale.js
@@ -123,6 +123,9 @@ export default class RatingScaleWidget extends Widget {
     container.on('mousedown', function (event) {
       this.response(event)
     }.bind(this))
+    container.on('touchstart', function (event) {
+      this.response(event)
+    }.bind(this))
   }
 
   /** Draw a label element


### PR DESCRIPTION
I added a cats, dogs, and capybara experiment. It's fairly complicated, but works flawlessly, so that's great! When bundled as a standalone `.html` it's almost 20 Mb, but still runs.

In addition, I added support for touch events, which were ignored. Could you check whether my implementation makes sense?

More generally, experiments aren't very mobile-friendly yet, in terms of resizing the window content. But let's consider that separately.