### PR TITLE
Allow touchstart events in touch-based browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "osweb",
-	"version": "1.2.4",
+	"version": "1.2.5",
 	"main": "src/js/osweb/index.js",
 	"description": "Online runtime for OpenSesame experiments",
 	"license": "GPL-3.0",

--- a/src/js/osweb/system/screen.js
+++ b/src/js/osweb/system/screen.js
@@ -278,6 +278,7 @@ export default class Screen {
       var clickHandler = function (event) {
         // Remove the handler.
         this._runner._renderer.view.removeEventListener('click', clickHandler)
+        this._runner._renderer.view.removeEventListener('touchstart', clickHandler)
 
         // Finalize the introscreen elements.
         this._clearIntroScreen()
@@ -288,6 +289,7 @@ export default class Screen {
 
       // Set the temporary mouse click.
       this._runner._renderer.view.addEventListener('click', clickHandler, false)
+      this._runner._renderer.view.addEventListener('touchstart', clickHandler, false)
     } else {
       // Finalize the introscreen elements.
       this._clearIntroScreen()


### PR DESCRIPTION
It's currently not possible to start experiments on Android, and presumably other touch-based browsers as well. This is because `touchstart` events aren't accepted in the startup screen.