### PR TITLE
Add basic support for inline javascript

### DIFF
--- a/example-experiments/inline_javascript.osexp
+++ b/example-experiments/inline_javascript.osexp
@@ -1,0 +1,149 @@
+---
+API: 2.1
+OpenSesame: 3.2.7a1
+Platform: posix
+---
+set width 1024
+set uniform_coordinates yes
+set title "JavaScript test"
+set subject_parity even
+set subject_nr 0
+set start experiment
+set sound_sample_size -16
+set sound_freq 48000
+set sound_channels 2
+set sound_buf_size 1024
+set sampler_backend legacy
+set round_decimals 2
+set mouse_backend legacy
+set keyboard_backend legacy
+set height 768
+set fullscreen no
+set form_clicks no
+set foreground white
+set font_underline no
+set font_size 18
+set font_italic no
+set font_family mono
+set font_bold no
+set experiment_path "/home/sebastiaan/git/osweb/example-experiments"
+set disable_garbage_collection yes
+set description "The main experiment item"
+set coordinates uniform
+set compensation 0
+set color_backend legacy
+set clock_backend legacy
+set canvas_backend legacy
+set background black
+
+define loop block_loop
+	set source table
+	set repeat 10
+	set order random
+	set description "Repeatedly runs another item"
+	set cycles 1
+	set continuous no
+	set break_if_on_first yes
+	set break_if never
+	setcycle 0 empty_column ""
+	run trial_sequence
+
+define sequence experiment
+	set flush_keyboard yes
+	set description "Runs a number of items in sequence"
+	run instructions always
+	run block_loop always
+	run new_feedback always
+
+define sketchpad fixdot
+	set duration 500
+	set description "Displays stimuli"
+	draw fixdot color=white show_if=always style=default x=0 y=0 z_index=0
+
+define feedback green_dot
+	set reset_variables no
+	set duration 500
+	set description "Provides feedback to the participant"
+	draw fixdot color=green show_if=always style=default x=0 y=0 z_index=0
+
+define sketchpad instructions
+	set duration keypress
+	set description "Displays stimuli"
+	draw textline center=1 color=white font_bold=no font_family=mono font_italic=no font_size=18 html=yes show_if=always text="INSTRUCTIONS<br /><br />Press 'z' if you see a blue F<br />Press 'z' if you don't<br /><br />Press any key to continue!" x=0 y=0 z_index=0
+
+define feedback new_feedback
+	set reset_variables yes
+	set duration keypress
+	set description "Provides feedback to the participant"
+	draw textline center=1 color=white font_bold=no font_family=mono font_italic=no font_size=18 html=yes show_if=always text="Finished!<br /><br />Your average RT was [avg_rt] ms<br />Your accuracy was [acc] %<br /><br />Press any key to exit!" x=0 y=0 z_index=0
+
+define feedback red_dot
+	set reset_variables no
+	set duration 500
+	set description "Provides feedback to the participant"
+	draw fixdot color=red show_if=always style=default x=0 y=0 z_index=0
+
+define sketchpad search_display
+	set duration 0
+	set description "Displays stimuli"
+	draw textline center=1 color="[color0]" font_bold=no font_family=mono font_italic=no font_size=48 html=yes show_if=always text="[stim0]" x="[x0]" y="[y0]" z_index=0
+	draw textline center=1 color="[color1]" font_bold=no font_family=mono font_italic=no font_size=48 html=yes show_if=always text="[stim1]" x="[x1]" y="[y1]" z_index=0
+	draw textline center=1 color="[color2]" font_bold=no font_family=mono font_italic=no font_size=48 html=yes show_if=always text="[stim2]" x="[x2]" y="[y2]" z_index=0
+	draw textline center=1 color="[color3]" font_bold=no font_family=mono font_italic=no font_size=48 html=yes show_if=always text="[stim3]" x="[x3]" y="[y3]" z_index=0
+
+define keyboard_response search_response
+	set timeout infinite
+	set flush yes
+	set event_type keypress
+	set duration keypress
+	set description "Collects keyboard responses"
+	set allowed_responses "z;m"
+
+define inline_javascript trial_script
+	set description "Executes JavaScript code (ECMA 5.1)"
+	set _run ""
+	___prepare__
+	function shuffle(array) {
+	    let counter = array.length;
+	
+	    // While there are elements in the array
+	    while (counter > 0) {
+	        // Pick a random index
+	        let index = Math.floor(Math.random() * counter);
+			console.log(index, array, array.length)
+	        // Decrease counter by 1
+	        counter--;
+	
+	        // And swap the last element with it
+	        let temp = array[counter];
+	        array[counter] = array[index];
+	        array[index] = temp;
+	    }
+	    return array
+	}
+	
+	let stimuli = shuffle(['F', 'H', 'E', 'Z'])
+	let colors = shuffle(['blue', 'yellow', 'blue', 'yellow'])
+	
+	vars.correct_response = 'm'
+	for (let i = 0; i <= 3; i++) {
+		vars['x' + i] = Math.floor(Math.random() * 200 - 100)
+		vars['y' + i] = Math.floor(Math.random() * 200 - 100)
+		vars['stim' + i] = stimuli[i]
+		vars['color' + i] = colors[i]
+		if (stimuli[i] == 'F' && colors[i] == 'blue') {
+			vars.correct_response = 'z'
+		}
+	}
+	__end__
+
+define sequence trial_sequence
+	set flush_keyboard yes
+	set description "Runs a number of items in sequence"
+	run trial_script always
+	run fixdot always
+	run search_display always
+	run search_response always
+	run green_dot "[correct] = 1"
+	run red_dot "[correct] = 0"
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "osweb",
-	"version": "1.2.5",
+	"version": "1.3.0",
 	"main": "src/js/osweb/index.js",
 	"description": "Online runtime for OpenSesame experiments",
 	"license": "GPL-3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "osweb",
-	"version": "1.2.6",
+	"version": "1.3.0",
 	"main": "src/js/osweb/index.js",
 	"description": "Online runtime for OpenSesame experiments",
 	"license": "GPL-3.0",

--- a/src/js/osweb/classes/javascript_workspace.js
+++ b/src/js/osweb/classes/javascript_workspace.js
@@ -1,4 +1,20 @@
 /**
+ * A proxy handler for the VarStore that maps properties onto calls to
+ * VarStore.get(), so that variables are automatically evaluated, just like
+ * in the OpenSesame `var` API.
+ */
+class VarStoreHandler {
+
+  get(target, prop) {
+    return typeof target[prop] === 'string'
+      ? target.get(prop)
+      : target[prop]
+  }
+
+}
+
+
+/**
  * A workspace for executing inline JavaScript code. For now, the workspace is
  * not persistent, and only exposes the vars object.
  */
@@ -10,6 +26,7 @@ export default class JavaScriptWorkspace {
      */
   constructor(experiment) {
     this.experiment = experiment
+    this.vars_proxy = new Proxy(this.experiment.vars, VarStoreHandler)
   }
 
   /**
@@ -17,7 +34,7 @@ export default class JavaScriptWorkspace {
      * @param {String} js - JavaScript code to execute
      */
   _eval(js) {
-    let vars = this.experiment.vars
+    let vars = this.vars_proxy
     eval(js)
   }
 }

--- a/src/js/osweb/classes/javascript_workspace.js
+++ b/src/js/osweb/classes/javascript_workspace.js
@@ -1,0 +1,23 @@
+/**
+ * A workspace for executing inline JavaScript code. For now, the workspace is
+ * not persistent, and only exposes the vars object.
+ */
+export default class JavaScriptWorkspace {
+
+  /**
+     * Create a JavaScript workspace.
+     * @param {Object} experiment - The experiment item to which the item belongs.
+     */
+  constructor(experiment) {
+    this.experiment = experiment
+  }
+
+  /**
+     * Executes JavaScript code in the workspace.
+     * @param {String} js - JavaScript code to execute
+     */
+  _eval(js) {
+    let vars = this.experiment.vars
+    eval(js)
+  }
+}

--- a/src/js/osweb/classes/var_store.js
+++ b/src/js/osweb/classes/var_store.js
@@ -17,33 +17,35 @@ export default class VarStore {
    * @param {Boolean|Number|String} defaultValue - The default value for the variable.
    * @param {Object} evaluate - The parent global var_store.
    * @param {Object} valid - The parent global var_store.
+   * @param {Boolean} addQuotes - The add quotes toggle.
    * @return {Boolean|Number|String} - The value of the given variable.
    */
-  get (variable, defaultValue, evaluate, valid) {
+  get (variable, defaultValue, evaluate, valid, addQuotes) {
     // Set the optional arguments
     defaultValue = (typeof defaultValue === 'undefined') ? null : defaultValue
     evaluate = (typeof evaluate === 'undefined') ? true : evaluate
     valid = (typeof valid === 'undefined') ? null : valid
-
     var value = null
-
     // Gets an experimental variable.
     if (variable in this) {
-      if (typeof this[variable] === 'string') {
-        value = this._item.syntax.eval_text(this[variable], null, true)
+      this._bypass_proxy = true // Avoid Proxy feedback loop
+      if (typeof this[variable] === 'string' && evaluate === true) {
+        value = this._item.syntax.eval_text(this[variable], null, addQuotes)
       } else {
         value = this[variable]
       }
+      this._bypass_proxy = false
     }
     // If value is not found locally, look in experiment object.
     if (value == null && this._parent && variable in this._parent) {
-      if (typeof this._parent[variable] === 'string') {
-        value = this._item.syntax.eval_text(this._parent[variable], null, true)
+      this._parent._bypass_proxy = true // Avoid Proxy feedback loop
+      if (typeof this._parent[variable] === 'string' && evaluate === true) {
+        value = this._item.syntax.eval_text(this._parent[variable], null, addQuotes)
       } else {
         value = this._parent[variable]
       }
+      this._parent._bypass_proxy = false
     }
-
     // Return function result.
     return value
   }

--- a/src/js/osweb/items/experiment.js
+++ b/src/js/osweb/items/experiment.js
@@ -1,4 +1,5 @@
 import Item from './item.js'
+import JavaScriptWorkspace from '../classes/javascript_workspace.js'
 import Canvas from '../backends/canvas.js'
 import Log from '../backends/log'
 import {
@@ -25,6 +26,7 @@ export default class Experiment extends Item {
     this._log = new Log(this)
     this._scale_x = 1 // Scaling of the canvas for fullscreen mode.
     this._scale_y = 1 // Scaling of the canvas for fullscreen mode.
+    this._javascriptWorkspace = new JavaScriptWorkspace(this)
 
     // Create and set public properties.
     this.debug = this._runner._debugger.enabled

--- a/src/js/osweb/items/inline_javascript.js
+++ b/src/js/osweb/items/inline_javascript.js
@@ -1,5 +1,4 @@
 import Item from './item.js'
-import JavaScriptWorkspace from '../classes/javascript_workspace.js'
 
 /**
  * Class representing an inline item.
@@ -17,7 +16,7 @@ export default class InlineJavaScript extends Item {
     super(experiment, name, script)
     // Define and set the public properties.
     this.description = 'Executes JavaScript code (ECMA 5.1)'
-    this.workspace = new JavaScriptWorkspace(this.experiment)
+    this.workspace = experiment._javascriptWorkspace
     // Process the script
     console.log(this.vars)
     this.from_string(script)

--- a/src/js/osweb/items/inline_javascript.js
+++ b/src/js/osweb/items/inline_javascript.js
@@ -1,0 +1,92 @@
+import Item from './item.js'
+import JavaScriptWorkspace from '../classes/javascript_workspace.js'
+
+/**
+ * Class representing an inline item.
+ * @extends Item
+ */
+export default class InlineJavaScript extends Item {
+  /**
+     * Create an inline item which executes inline python code.
+     * @param {Object} experiment - The experiment item to which the item belongs.
+     * @param {String} name - The unique name of the item.
+     * @param {String} script - The script containing the properties of the item.
+     */
+  constructor (experiment, name, script) {
+    // Inherited create.
+    super(experiment, name, script)
+    // Define and set the public properties.
+    this.description = 'Executes JavaScript code (ECMA 5.1)'
+    this.workspace = new JavaScriptWorkspace(this.experiment)
+    // Process the script
+    console.log(this.vars)
+    this.from_string(script)
+  }
+
+  /** Reset all item variables to their default value. */
+  reset () {
+    this.vars._prepare = ''
+    this.vars._run = ''
+  }
+
+  /**
+     * Parse a definition string and retrieve all properties of the item.
+     * @param {String} script - The script containing the properties of the item.
+     */
+  from_string (script) {
+    // Parses a definition string.
+    this.reset()
+    // Split the string into an array of lines.
+    if (script !== null) {
+      var read_run_lines = false
+      var read_prepare_lines = false
+      var lines = script.split('\n')
+      for (var i = 0; i < lines.length; i++) {
+        var tokens = this.syntax.split(lines[i])
+        if ((tokens !== null) && (tokens.length > 0)) {
+          switch (tokens[0]) {
+            case 'set':
+              this.parse_variable(lines[i])
+              break
+            case '__end__':
+              read_run_lines = false
+              read_prepare_lines = false
+              break
+            case '___prepare__':
+              read_prepare_lines = true
+              break
+            case '___run__':
+              read_run_lines = true
+              break
+            default:
+              if (read_run_lines === true) {
+                this.vars._run = this.vars._run + lines[i] + '\n'
+              } else if (read_prepare_lines === true) {
+                this.vars._prepare = this.vars._prepare + lines[i] + '\n'
+              }
+          }
+        } else {
+          if (read_run_lines === true) {
+            this.vars._run = this.vars._run + lines[i] + '\n'
+          } else if (read_prepare_lines === true) {
+            this.vars._prepare = this.vars._prepare + lines[i] + '\n'
+          }
+        }
+      }
+    }
+  }
+
+  /** Implements the prepare phase of an item. */
+  prepare () {
+    this.workspace._eval(this.vars._prepare)
+    super.prepare()
+  }
+
+  /** Implements the run phase of an item. */
+  run () {
+    super.run()
+    this.set_item_onset()
+    this.workspace._eval(this.vars._run)
+    this._complete()
+  }
+}

--- a/src/js/osweb/system/constants.js
+++ b/src/js/osweb/system/constants.js
@@ -6,6 +6,7 @@ import Sketchpad from '../items/sketchpad.js'
 import Feedback from '../items/feedback.js'
 // Scripts
 import InlineScript from '../items/inline_script.js'
+import InlineJavaScript from '../items/inline_javascript.js'
 // Responses
 import KeyboardResponse from '../items/keyboard_response.js'
 import MouseResponse from '../items/mouse_response'
@@ -62,6 +63,7 @@ export const itemClasses = {
   sketchpad: Sketchpad,
   feedback: Feedback,
   inline_script: InlineScript,
+  inline_javascript: InlineJavaScript,
   keyboard_response: KeyboardResponse,
   mouse_response: MouseResponse,
   logger: Logger,


### PR DESCRIPTION
Allows for inline JavaScript code in OSWeb through the `inline_javascript` plugin that is bundled with the OSWeb extension. To allow JavaScript to be executed on the desktop, [Js2Py](https://github.com/PiotrDabkowski/Js2Py) is used.

Supports:

- Access to the `vars` object for setting experimental variables.
- ECMA Script 5.1 within Python. There is some flexibility here. For example, the `let` keyword is accepted even though this is ECMA Script 6.

Limitations: 

- Does not support `Canvas` objects and other parts of the Python API. This would be possible, but would require considerable improvements to the JavaScript implementation of these classes.
- <strike>When there is an error in the JavaScript code and the experiment is executed in OpenSesame, the process closes silently, without any error message. This strikes me as a bug/ limitation in js2py.</strike>

Several packages have been updated to support this:

- shyras/osweb@6ba2cf6 (see shyras/osweb#121)
- smathot/OpenSesame@53d491e
- smathot/QProgEdit@f7c5fa7   (`release/4.1.0`)
- smathot/opensesame-extension-osweb@d4bab0a (see smathot/opensesame-extension-osweb#12)
