### PR TITLE
canvas: gabor orientations are clockwise

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "osweb",
-	"version": "1.2.5",
+	"version": "1.2.6",
 	"main": "src/js/osweb/index.js",
 	"description": "Online runtime for OpenSesame experiments",
 	"license": "GPL-3.0",

--- a/src/js/osweb/backends/canvas.js
+++ b/src/js/osweb/backends/canvas.js
@@ -500,7 +500,7 @@ export default class Canvas {
     const px = ctx.getImageData(0, 0, size, size)
 
     // Conver the orientation to radians.
-    orient = Math.PI * orient / 180
+    orient = Math.PI * orient / -180
     color1 = this._styles._convertColorValueToRGB(color1)
     color2 = this._styles._convertColorValueToRGB(color2)
 


### PR DESCRIPTION
This is a very minor change that is related to smathot/OpenSesame#656. The orientation parameter of gabor patches used to be interpreted inconsistently. This has been fixed so that it always refers to a clockwise rotation from a vertical.