### PR TITLE
Fixes #128

### DIFF
--- a/src/js/osweb/items/generic_response.js
+++ b/src/js/osweb/items/generic_response.js
@@ -75,7 +75,7 @@ export default class GenericResponse extends Item {
       // Create a list of allowed responses that are separated by semicolons.
       // Also trim any whitespace.
       const allowed_responses = this.vars.get('allowed_responses').split(';')
-        .map(item => item.trim().replace(/^"(.*)"$/g, '$1'))
+        .map(item => item.replace(/^"(.*)"$/g, '$1').trim())
       if (this.vars.duration === 'keypress') {
         // this._allowed_responses = allowed_responses;
         this._allowed_responses = this._keyboard._get_default_from_synoniem(allowed_responses)

--- a/src/js/osweb/items/generic_response.js
+++ b/src/js/osweb/items/generic_response.js
@@ -50,9 +50,11 @@ export default class GenericResponse extends Item {
   _update (response) {
     if (response !== null) {
       // Implements the update response phase of the item.
-      if ((this._responsetype === constants.RESPONSE_KEYBOARD) && (response.type === constants.RESPONSE_KEYBOARD)) {
+      if ((this._responsetype === constants.RESPONSE_KEYBOARD) &&
+        (response.type === constants.RESPONSE_KEYBOARD)) {
         this.process_response_keypress(response)
-      } else if ((this._responsetype === constants.RESPONSE_MOUSE) && (response.type === constants.RESPONSE_MOUSE)) {
+      } else if ((this._responsetype === constants.RESPONSE_MOUSE) &&
+        (response.type === constants.RESPONSE_MOUSE)) {
         this.process_response_mouseclick(response)
       }
     }
@@ -70,8 +72,10 @@ export default class GenericResponse extends Item {
     if (this.vars.get('allowed_responses') === null) {
       this._allowed_responses = null
     } else {
-      // Create a list of allowed responses that are separated by semicolons. Also trim any whitespace.
-      var allowed_responses = String(this.vars.allowed_responses).split(';')
+      // Create a list of allowed responses that are separated by semicolons.
+      // Also trim any whitespace.
+      const allowed_responses = this.vars.get('allowed_responses').split(';')
+        .map(item => item.trim().replace(/^"(.*)"$/g, '$1'))
       if (this.vars.duration === 'keypress') {
         // this._allowed_responses = allowed_responses;
         this._allowed_responses = this._keyboard._get_default_from_synoniem(allowed_responses)
@@ -82,7 +86,9 @@ export default class GenericResponse extends Item {
 
       // If allowed responses are provided, the list should not be empty.
       if (this._allowed_responses.length === 0) {
-        this.experiment._runner._debugger.addError('Defined responses are not valid in keyboard_response: ' + this.name + ' (' + this.vars.get('allowed_responses') + ')')
+        this.experiment._runner._debugger.addError(
+          'Defined responses are not valid in keyboard_response: ' +
+          this.name + ' (' + this.vars.get('allowed_responses') + ')')
       }
     }
   }

--- a/src/js/osweb/items/generic_response.js
+++ b/src/js/osweb/items/generic_response.js
@@ -74,8 +74,10 @@ export default class GenericResponse extends Item {
     } else {
       // Create a list of allowed responses that are separated by semicolons.
       // Also trim any whitespace.
-      const allowed_responses = this.vars.get('allowed_responses').split(';')
-        .map(item => item.replace(/^"(.*)"$/g, '$1').trim())
+      const allowed_responses = String(this.vars.get('allowed_responses')).split(';')
+        .map(item => (typeof item === 'string')
+          ? item.replace(/^"(.*)"$/g, '$1').trim()
+          : item)
       if (this.vars.duration === 'keypress') {
         // this._allowed_responses = allowed_responses;
         this._allowed_responses = this._keyboard._get_default_from_synoniem(allowed_responses)


### PR DESCRIPTION
I'm quite unhappy with this fix, so regard this as temporary. I didn't want to be too invasive into the `var_store.get()` method, where things go wrong. The problem is that var_store's `get` method always tells syntax's `eval_text` method to add quotes to resolved string values, and there is no way from the outside of the `get` method to control for this. One could add an extra parameter to it make this possible, but firstly, I don't think this is an elegant solution, and secondly I have restructured `var_store.get()` already quite a bit in the coroutines PR, so I didn't want to do so too in this PR and cause git conflict hell.
So I now just added an extra operation that removes the undesired quotes that were just added before. Not really efficient I'd say...
