### PR TITLE
Memory loss for the log

### DIFF
--- a/src/js/osweb/backends/log.js
+++ b/src/js/osweb/backends/log.js
@@ -21,10 +21,13 @@ export default class Log {
    */
   _get_all_vars () {
     // Retrieves a list of all variables that exist in the experiment.
+    /*
     if (this._all_vars === null) {
       this._all_vars = this._experiment.vars.inspect()
     }
     return this._all_vars
+    */
+    return this._experiment.vars.inspect()
   }
 
   /** Closes the current log. */


### PR DESCRIPTION
Very simple fix to solve this for now, but we may want to try and think of a more durable solution in the future. This, and many other problems, are caused by osweb trying to stay too close to OpenSesame, while osweb is in a completely different playing field. One day, we may make things like these more elegant in a (partial) rewrite of osweb.