### PR TITLE
Fix logger and polish var_store

### DIFF
--- a/src/js/osweb/backends/log.js
+++ b/src/js/osweb/backends/log.js
@@ -7,69 +7,7 @@ export default class Log {
    * @param {Object} experiment - The experiment to which the logger belongs.
    */
   constructor (experiment) {
-    // Create and set private properties.
-    this._all_vars = null // If true all variables are written to the log.
     this._experiment = experiment // Anchor to the experiment object.
-    this._experiment.vars.logfile = '' // Store the path location into the vars list.
-    this._header_written = false // If true the header has been written to the log.
-    this._log = [] // Array containing the log entries.
-  }
-
-  /**
-   * Retrieves a list of all variables that exist in the experiment.
-   * @return {Array} - A list of all variables.
-   */
-  _get_all_vars () {
-    // Retrieves a list of all variables that exist in the experiment.
-    /*
-    if (this._all_vars === null) {
-      this._all_vars = this._experiment.vars.inspect()
-    }
-    return this._all_vars
-    */
-    return this._experiment.vars.inspect()
-  }
-
-  /** Closes the current log. */
-  close () {
-    // Closes the current log.
-    if (this._log.length > 0) {
-      // Echo the data to the runner.
-      this._experiment._runner._data = this._log.join('')
-    };
-
-    // Clear the log file.
-    this._log = []
-  }
-
-  /** Opens the current log. If a log was already open, it is closed. */
-  open () {
-    // Opens the current log. If a log was already open, it is closed.
-    this._header_written = false
-
-    // Check for old data.
-    if (this._log !== null) {
-      // Clear the old data.
-      this.close()
-    }
-  }
-
-  /**
-   * Write one signle line to the message log.
-   * @param {String} msg - Message to add to the log file.
-   * @param {Boolean} newLine - If true a new line character is inserted into the message.
-   */
-  write (msg, newLine) {
-    // Write one message to the log.
-    newLine = (typeof newLine === 'undefined') ? true : newLine
-
-    if (newLine === true) {
-      // Write a log with a new line.
-      this._log.push(msg + '\n')
-    } else {
-      // Write a log without a new line.
-      this._log.push(msg)
-    }
   }
 
   /**
@@ -77,42 +15,14 @@ export default class Log {
    * @param {Array} varList - Array with variables to write to the log.
    */
   write_vars (varList) {
-    // Writes variables to the log.
-    varList = (typeof varList === 'undefined') ? null : varList
-
-    var value
-    var l = []
-    // If no var list defined, retrieve all variables.
-    if (varList === null) {
-      varList = this._get_all_vars()
-    }
-
-    // Sort the var list.
-    varList.sort()
-
-    // Add the header to the log file.
-    if (this._header_written === false) {
-      for (var i = 0; i < varList.length; i++) {
-        l.push('"' + varList[i] + '"')
-      }
-      this.write(l.join())
-      this._header_written = true
-    }
-
-    // Add the data entries to the log file.
-    l = []
-    const entry = {}
-    for (let i = 0; i < varList.length; i++) {
-      value = this._experiment.vars.get(varList[i], 'NA', false)
+    if (!isFunction(this._experiment.onLog)) return
+    let entry = {}
+    let value
+    for (let varName of varList) {
+      value = this._experiment.vars.get(varName, 'NA', false)
       if (isFunction(value)) continue
-      l.push('"' + value + '"')
-      entry[varList[i]] = value
+      entry[varName] = value
     }
-    this.write(l.join())
-
-    // If event is attached to the experiment output log.
-    if (isFunction(this._experiment.onLog)) {
-      this._experiment.onLog(entry)
-    }
+    this._experiment.onLog(entry)
   }
 }

--- a/src/js/osweb/backends/log.js
+++ b/src/js/osweb/backends/log.js
@@ -21,10 +21,13 @@ export default class Log {
    */
   _get_all_vars () {
     // Retrieves a list of all variables that exist in the experiment.
+    /*
     if (this._all_vars === null) {
       this._all_vars = this._experiment.vars.inspect()
     }
     return this._all_vars
+    */
+    return this._experiment.vars.inspect()
   }
 
   /** Closes the current log. */

--- a/src/js/osweb/classes/var_store.js
+++ b/src/js/osweb/classes/var_store.js
@@ -9,6 +9,9 @@ export default class VarStore {
     // Create and set private properties.
     this._item = item
     this._parent = parent
+    this._ignored_properties = [
+      '_item', '_parent', '_bypass_proxy', '_ignored_properties'
+    ]
   };
 
   /**
@@ -56,31 +59,31 @@ export default class VarStore {
    * @return {Boolean} - True if the variable is part of the store.
    */
   has (variable) {
-    // Check if the variable (property) is part of the class.
-    return this.hasOwnProperty(variable)
+    return this.inspect().contains(variable)
   }
 
   /** Create a list of all avariables available.
    * @return {Array} - Array containing names of all variables.
    */
   inspect () {
-    // Get all variable values.
-    var keys = []
-    for (var key in this) {
-      keys.push(key)
+    let variables = []
+    for (let variable in this) {
+      if (this._ignored_properties.includes(variable)) continue
+      variables.push(variable)
     }
-
-    // Slide default properties (HACK for removing the defauly properties/methods from the log_list).
-    keys = keys.slice(2, -7)
-
-    // Return function result.
-    return keys
+    return variables
   }
 
   /** Create a list of value/name pairs.
    * @return {Array} - Array containing name and values of all variables.
    */
-  items () {}
+  items () {
+    let pairs = {}
+    for (let variable of this.inspect()) {
+      pairs[variable] = this[variable]
+    }
+    return pairs
+  }
 
   /**
    * Set the value of a variable in the store.
@@ -88,7 +91,6 @@ export default class VarStore {
    * @value {Boolean|Number|String} - Value of the variable to set.
    */
   set (variable, value) {
-    // Sets and experimental variable.
     this[variable] = value
   }
 
@@ -97,15 +99,28 @@ export default class VarStore {
    * @param {String} variable - The name of the variable.
    */
   unset (variable) {
-    // Check if the variable exists.
     if (this.has(variable) === true) {
-      // Remove the variable as property from the object.
       delete this[variable]
     }
   }
 
-  /** Create a list of variable values.
-   * @return {Array} - Array containing values of all variables.
+  /** Create a list of variable names.
+   * @return {Array} - Array containing namesof all variables.
    */
-  vars () {}
+  vars () {
+    return this.inspect()
+  }
+
+  /**
+   * Clears all experimental variables, except those that are explicitly
+   * preserved.
+   * @param {Array} preserve - An array of variable names to preserve.
+   */
+  clear (preserve) {
+    preserve = (typeof preserve === 'undefined') ? [] : preserve
+    for (let variable of this.inpsect()) {
+      if (preserve.includes(variable)) continue
+      this.unset(variable)
+    }
+  }
 }

--- a/src/js/osweb/items/experiment.js
+++ b/src/js/osweb/items/experiment.js
@@ -163,11 +163,6 @@ export default class Experiment extends Item {
     this._canvas.init_display(this)
   }
 
-  /** Open a connection to the log file. */
-  init_log () {
-    this._log.open()
-  }
-
   /** Event handler for external data retrieval. */
   onLog (data) {
     // Function to be overwritten by external handler
@@ -190,7 +185,6 @@ export default class Experiment extends Item {
         this.vars.opensesame_codename = VERSION_NAME
         this.init_clock()
         this.init_display()
-        this.init_log()
         this.reset_feedback()
 
         // Add closing message to debug system.
@@ -215,10 +209,6 @@ export default class Experiment extends Item {
 
   /** Ends an experiment. */
   end () {
-    // Close the log file.
-    this._log.close()
-
-    // Finalize the parent (runner).
     this._runner._finalize()
   }
 }

--- a/src/js/osweb/items/logger.js
+++ b/src/js/osweb/items/logger.js
@@ -13,17 +13,8 @@ export default class Logger extends Item {
      * @param {String} pScript - The script containing the properties of the item.
      */
   constructor (experiment, name, script) {
-    // Inherited create.
     super(experiment, name, script)
-
-    // Definition of public properties.
     this.description = 'Logs experimental data'
-    this.logvars = []
-
-    // Definition of private properties.
-    this._logvars = null
-
-    // Process the script.
     this.from_string(script)
   }
 
@@ -35,7 +26,6 @@ export default class Logger extends Item {
 
   /** Reset all item variables to their default value. */
   reset () {
-    this._logvars = null
     this.logvars = []
     this.vars.auto_log = 'yes'
   }
@@ -45,12 +35,7 @@ export default class Logger extends Item {
      * @param {String} script - The script containing the properties of the item.
      */
   from_string (script) {
-    // Parses a definition string.
-    this.variables = {}
-    this.comments = []
     this.reset()
-
-    // Split the string into an array of lines.
     if (script !== null) {
       var lines = script.split('\n')
       for (var i = 0; i < lines.length; i++) {
@@ -62,36 +47,20 @@ export default class Logger extends Item {
         }
       }
     }
+    this.logvars.sort()
   }
 
   /** Implements the run phase of an item. */
   run () {
-    // Inherited.
     super.run()
-
-    // Run item only one time.
     if (this._status !== constants.STATUS_FINALIZE) {
-      // item is finalized.
       this._status = constants.STATUS_FINALIZE
-
       this.set_item_onset()
-      if (this._logvars == null) {
-        if (this.vars.auto_log === 'yes') {
-          this._logvars = this.experiment._log._get_all_vars()
-        } else {
-          this._logvars = []
-          for (const variable of this.logvars) {
-            if ((variable in this._logvars) === false) {
-              this._logvars.push(variable)
-            }
-          }
-          this._logvars.sort()
-        }
-      }
-
-      this.experiment._log.write_vars(this._logvars)
-
-      // Complete the cycle.
+      this.experiment._log.write_vars(
+        (this.vars.get('auto_log') === 'yes')
+        ? this.logvars.concat(this.experiment.vars.inspect()).sort()
+        : this.logvars
+      )
       this._complete()
     }
   }

--- a/src/js/osweb/items/loop.js
+++ b/src/js/osweb/items/loop.js
@@ -198,7 +198,7 @@ export default class Loop extends Item {
   prepare () {
     // Prepare the break if condition.
     if ((this.vars.break_if !== '') && (this.vars.break_if !== 'never')) {
-      this._break_if = this.syntax.compile_cond(this.vars.break_if)
+      this._break_if = this.syntax.compile_cond(this.vars.get('break_if'))
     } else {
       this._break_if = null
     }
@@ -208,7 +208,7 @@ export default class Loop extends Item {
     this._index = 0
 
     // Walk through all complete repeats
-    var wholeRepeats = Math.floor(this.vars.repeat)
+    var wholeRepeats = Math.floor(this.vars.get('repeat'))
     for (let j = 0; j < wholeRepeats; j++) {
       for (let i = 0; i < this.vars.cycles; i++) {
         this._cycles.push(i)
@@ -216,7 +216,7 @@ export default class Loop extends Item {
     }
 
     // Add the leftover repeats.
-    const partialRepeats = this.vars.repeat - wholeRepeats
+    const partialRepeats = this.vars.get('repeat') - wholeRepeats
     if (partialRepeats > 0) {
       const allCycles = Array.apply(null, {
         length: this.vars.cycles
@@ -233,24 +233,25 @@ export default class Loop extends Item {
     }
 
     // Randomize the list if necessary.
-    if (this.vars.order === 'random') {
+    if (this.vars.get('order') === 'random') {
       this._cycles = shuffle(this._cycles)
     } else {
+      const skipVal = this.vars.get('skip')
       // In sequential order, the offset and the skip are relevant.
-      if (this._cycles.length < this.vars.skip) {
+      if (this._cycles.length < skipVal) {
         this.experiment._runner._debugger.addError('The value of skip is too high in loop item. You cannot skip more cycles than there are in: ' + this.name)
       } else {
-        if (this.vars.offset === 'yes') {
+        if (this.vars.get('offset') === 'yes') {
           // Get the skip elements.
-          const skip = this._cycles.slice(0, this.vars.skip)
+          const skip = this._cycles.slice(0, skipVal)
 
           // Remove the skip elements from the original location.
-          this._cycles = this._cycles.slice(this.vars.skip)
+          this._cycles = this._cycles.slice(skipVal)
 
           // Add the skip element to the end.
           this._cycles = this._cycles.concat(skip)
         } else {
-          this._cycles = this._cycles.slice(this.vars.skip)
+          this._cycles = this._cycles.slice(skipVal)
         }
       }
     }


### PR DESCRIPTION
The main goal of this PR is to fix #133. However, in the process I've also fixed the API of the `var_store`, such that it now works and matches the Python API. The `logger` now also works as expected when disabling/ enabling the 'Log all variables' option and/ or adding custom variables.

PS. Sorry for also including the fix/134 branch. Didn't notice that.