### PR TITLE
Fixes #140

### DIFF
--- a/src/html/index.ejs
+++ b/src/html/index.ejs
@@ -7,8 +7,8 @@
 <html>
 
 <head>
-	<!-- Head - general definitions -->
-	<meta charset="UTF-8">
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title><%= htmlWebpackPlugin.options.title || 'Osweb'%></title>

--- a/src/js/osweb/backends/canvas.js
+++ b/src/js/osweb/backends/canvas.js
@@ -592,20 +592,20 @@ export default class Canvas {
    */
   image (fname, center, x, y, scale) {
     // Get image from file pool.
-    var name = this.experiment._runner._syntax.remove_quotes(fname)
-    var path = this.experiment._runner._pool[name]
+    let name = this.experiment._runner._syntax.remove_quotes(fname)
+    let path = this.experiment._runner._pool[name]
     if (typeof (path) === 'undefined') {
       this.experiment._runner._debugger.addError(`"${fname}" does not exist`)
     }
-    var img = path.data
+    let img = path.data
     // Create a temporary canvas to make an image data array.
-    var canvas = document.createElement('canvas')
+    let canvas = document.createElement('canvas')
     canvas.width = img.width
     canvas.height = img.height
-    var ctx = canvas.getContext('2d')
+    let ctx = canvas.getContext('2d')
     ctx.drawImage(img, 0, 0)
 
-    var sprite = new PIXI.Sprite(PIXI.Texture.fromCanvas(canvas))
+    let sprite = new PIXI.Sprite(PIXI.Texture.fromCanvas(canvas))
 
     // Scale the image.
     sprite.scale.x = scale

--- a/src/js/osweb/elements/textline.js
+++ b/src/js/osweb/elements/textline.js
@@ -33,10 +33,7 @@ export default class Textline extends BaseElement {
   draw () {
     // Inherited.
     super.draw()
-
-    // Decode text so unicode is converted properly.
-    const text = decodeURIComponent(escape(this._properties.text))
-
+    const text = this._properties.text
     // Create a styles object containing style information
     const styles = new Styles()
     styles.color = this._properties.color

--- a/src/js/osweb/items/loop.js
+++ b/src/js/osweb/items/loop.js
@@ -236,7 +236,6 @@ export default class Loop extends Item {
       }
     }
 
-    // Create a keyboard to flush responses between cycles.
     this._keyboard = new Keyboard(this.experiment)
 
     // Make sure the item to run exists.
@@ -245,19 +244,15 @@ export default class Loop extends Item {
       this.name + ' (' + this.vars.item + ')')
     }
 
-    // Inherited.
     super.prepare()
 
-    // Set the onset time.
     this.set_item_onset()
   }
 
   /** Implements the run phase of an item. */
   run () {
-    // Inherited.
     super.run()
 
-    // Prepare the break if condition.
     const break_if_val = this.vars.get('break_if')
     this._break_if = ['never', ''].includes(break_if_val)
       ? null
@@ -277,7 +272,6 @@ export default class Loop extends Item {
       this._index = this._cycles.shift()
       this.apply_cycle(this._index)
 
-      // Check the break_if flag.
       if (this._break_if !== null) {
         this.python_workspace['this'] = this
 
@@ -289,7 +283,6 @@ export default class Loop extends Item {
         }
       }
 
-      // Replace with execute
       if (this._runner._itemStore._items[this.vars.item].type === 'sequence') {
         this.experiment._runner._itemStore.prepare(this.vars.item, this)
       } else {

--- a/src/js/osweb/items/loop.js
+++ b/src/js/osweb/items/loop.js
@@ -266,7 +266,10 @@ export default class Loop extends Item {
     // Check if if the cycle must be repeated.
     if (this.experiment.vars.repeat_cycle === 1 && isNumber(this._index)) {
       this.experiment._runner._debugger.msg('Repeating cycle: ' + this._index)
-      this._cycles.unshift(this._index)
+      this._cycles.push(this._index)
+      if (this.vars.get('order') === 'random') {
+        this._cycles = shuffle(this._cycles)
+      }
       this.experiment.vars.repeat_cycle = 0
     }
 

--- a/src/js/osweb/items/loop.js
+++ b/src/js/osweb/items/loop.js
@@ -286,8 +286,6 @@ export default class Loop extends Item {
         }
       }
 
-      this.experiment.vars.repeat_cycle = 0
-
       // Replace with execute
       if (this._runner._itemStore._items[this.vars.item].type === 'sequence') {
         this.experiment._runner._itemStore.prepare(this.vars.item, this)

--- a/src/js/osweb/plugins/repeat_cycle.js
+++ b/src/js/osweb/plugins/repeat_cycle.js
@@ -33,9 +33,6 @@ export default class RepeatCycle extends Item {
 
   /** Implements the prepare phase of an item. */
   prepare () {
-    // Prepare the condtion for which the repeat_cycle must fire.
-    this._condition = this.syntax.compile_cond(this.vars.get('condition'))
-
     // Inherited.
     super.prepare()
   }
@@ -45,9 +42,11 @@ export default class RepeatCycle extends Item {
     // Inherited.
     super.run()
 
+    // Prepare the condtion for which the repeat_cycle must fire.
+    const condition = this.syntax.compile_cond(this.vars.get('condition'))
     // Run item only one time.
     if (this._status !== constants.STATUS_FINALIZE) {
-      if (this.experiment._runner._pythonWorkspace._eval(this._condition) === true) {
+      if (this.experiment._runner._pythonWorkspace._eval(condition) === true) {
         this.experiment.vars.repeat_cycle = 1
       }
 

--- a/src/js/osweb/system/transfer.js
+++ b/src/js/osweb/system/transfer.js
@@ -181,7 +181,12 @@ export default class Transfer {
         var item = {
           data: null,
           folder: currentFile.name.match(/(.*)[/\\]/)[1] || '',
-          name: currentFile.name.replace(/^.*[\\/]/, ''),
+          name: currentFile.name.replace(/^.*[\\/]/, '').replace(
+            /U\+([0-9A-F]{4})/g, (whole, group1) => {
+              // Parse encoded characters back to their unicode counterparts
+              return String.fromCharCode(parseInt(group1, 16))
+            }
+          ),
           size: currentFile.size,
           type: 'undefined'
         }

--- a/src/js/osweb/system/transfer.js
+++ b/src/js/osweb/system/transfer.js
@@ -72,7 +72,7 @@ export default class Transfer {
    * @returns boolean
    * @memberof Transfer
    */
-  async _readOsexpFromString (osexp) {
+  async _readExpFile (osexp) {
     if ([File, Blob].includes(osexp.constructor)) {
       osexp = await readFileAsText(osexp)
     }
@@ -85,7 +85,7 @@ export default class Transfer {
    */
   async _readOsexpFromFile (osexpFile) {
     try {
-      return await this._readOsexpFromString(osexpFile)
+      return await this._readExpFile(osexpFile)
     } catch (e) {
       this._runner._debugger.addMessage(`Could not read osexp file as plain text: ${e.message}.\nFile is probably binary`)
     }
@@ -100,7 +100,7 @@ export default class Transfer {
     if (expFileIndex === -1) throw new Error('Could not locate experiment script')
     // Pop the script out of the file array and proccess it
     const expFile = files.splice(expFileIndex, 1)[0]
-    const script = this._processScript(expFile.readAsString())
+    const script = await this._readExpFile(expFile.blob)
 
     // According to the zlib convention followed by the pako library we use to decompress
     // the osexp file, files have a type of 0, so filter these out.

--- a/src/js/tests/system/transfer.test.js
+++ b/src/js/tests/system/transfer.test.js
@@ -50,13 +50,13 @@ describe('Transfer class', () => {
     })
   })
 
-  describe('_readOsexpFromString', () => {
+  describe('_readExpFile', () => {
     it('Should throw an error if an invalid osexp representation is supplied', () => {
-      expect(transfer._readOsexpFromString('abc')).rejects.toThrow()
+      expect(transfer._readExpFile('abc')).rejects.toThrow()
     })
 
     it('Should recognize a valid script and update the status bar', () => {
-      expect(transfer._readOsexpFromString(osexpString)).resolves.toBe(osexpString)
+      expect(transfer._readExpFile(osexpString)).resolves.toBe(osexpString)
       expect(mockUpdateProgressBar).toHaveBeenCalledTimes(1)
       expect(mockUpdateProgressBar.mock.calls[0][0]).toBe(100)
     })


### PR DESCRIPTION
The fix seemed simple after all, but was hard to see due to the 'intricate' control flow of osweb ;)
I am however a bit confused about how `repeat_cycle` should actually work. My assumption was that it *directly* repeats the current cycle, and thus places it at the _front_ of the queue. However, if I run the test experiment in OpenSesame, it seems that the cycles to be repeated are placed at _the end_ of the queue, and only run again after all other cycles have been run first. If OpenSesame's behavior is the intended one, then I need to simply change `this._cycles.unshift()` to `this._cycles.push()` and that should do the trick. 