### PR TITLE
Fix correct responses in capybara example

### DIFF
--- a/src/js/osweb/classes/syntax.js
+++ b/src/js/osweb/classes/syntax.js
@@ -118,7 +118,6 @@ export default class Syntax {
     if (isNumber(text)) return text
     // Try to convert text to a number. If this succeeds return it.
     if (!isNaN(toNumber(text))) return toNumber(text)
-
     text = this.escapeBrackets(text)
     /** The replacer function detects variable entries in the passed text
     and replaces them with variable values as found in OpenSesame's var store */
@@ -142,7 +141,6 @@ export default class Syntax {
           if (typeof value === 'undefined') {
             throw new ReferenceError(`Variable '${content}' not present in var store`)
           }
-
           if (isString(value)) {
             if (value !== '') {
               value = this.eval_text(value, vars, addQuotes)
@@ -152,16 +150,17 @@ export default class Syntax {
           this._runner._debugger.addError(`Could not resolve variable '${content}': ${err.message}`)
           throw err
         }
-
         if (addQuotes === true) {
-          // Temporyary hack for string types.
+          // Temporary hack for string types.
           return isString(value) ? `"${value}"` : value
         } else {
           return value
         }
       }
     })
-
+    // Try to convert the result to a number again. If this succeeds return it.
+    let nr = toNumber(result)
+    if (!isNaN(nr)) return nr
     // Check if content has additional quotes
     return this.strip_slashes(this.unescapeBrackets(result))
   }

--- a/src/js/osweb/items/generic_response.js
+++ b/src/js/osweb/items/generic_response.js
@@ -243,11 +243,6 @@ export default class GenericResponse extends Item {
           }
         } else {
           this.experiment.vars.correct = 'undefined'
-          /* if self.experiment.response in (correct_response, safe_decode(correct_response)):
-              self.experiment.var.correct = 1
-              self.experiment.var.total_correct += 1
-            else:
-              self.experiment.var.correct = 0 */
         }
       } else {
         // If a correct_response hasn't been defined, we simply set correct to undefined.

--- a/src/js/tests/classes/syntax.test.js
+++ b/src/js/tests/classes/syntax.test.js
@@ -144,7 +144,7 @@ describe('Syntax', function () {
     })
     it('Should parse variables with underscores and numbers: [my_var99]', function () {
       expect(syntax.eval_text(
-        '[my_var99]', tmpVarStore)).toBe('99')
+        '[my_var99]', tmpVarStore)).toBe(99)
     })
     it('Should not try to parse a variable if it is preceded by a backslash: \\[width]', function () {
       expect(syntax.eval_text(
@@ -156,7 +156,7 @@ describe('Syntax', function () {
     })
     it('Should process python code: [=10*10]', function () {
       expect(syntax.eval_text(
-        '[=10*10]', tmpVarStore)).toBe('100')
+        '[=10*10]', tmpVarStore)).toBe(100)
     })
     it('Should not process python code if it is preceded by a backslash: \\[=10*10]', function () {
       expect(syntax.eval_text(


### PR DESCRIPTION
The issue was the `correct_response` variable was defined in terms of other variables. And `eval_text()` only convert literal numbers to numbers, not other kinds of expressions that evaluate to numbers.